### PR TITLE
Fix streaming encoder.

### DIFF
--- a/lib/webmachine/streaming.rb
+++ b/lib/webmachine/streaming.rb
@@ -9,15 +9,15 @@ module Webmachine
     include Enumerable
 
     def each
-      body.each do |block|
-        yield @resource.send(@encoder, resource.send(@charsetter, block))
+      @body.each do |block|
+        yield @resource.send(@encoder, @resource.send(@charsetter, block))
       end
     end
   end
 
   class CallableEncoder < StreamingEncoder
     def call
-      @resource.send(@encoder, @resource.send(@charsetter, body.call))
+      @resource.send(@encoder, @resource.send(@charsetter, @body.call))
     end
 
     def to_proc


### PR DESCRIPTION
There are no getter for response and body.

Without this patch I'm getting the following error when returning a Proc object in `to_html`.

```
[2011-09-01 13:13:49] INFO  Webmachine::Adapters::WEBrick::Server#start: pid=14382 port=3000
[2011-09-01 13:13:53] ERROR NameError: undefined local variable or method `body' for #<Webmachine::EnumerableEncoder:0x98bda7c>
    /home/bernd/projects/github/webmachine-ruby/lib/webmachine/streaming.rb:12:in `each'
/home/bernd/projects/github/webmachine-ruby/lib/webmachine/adapters/webrick.rb:38:in `service'
/home/bernd/.rvm/rubies/ruby-1.9.3-head/lib/ruby/1.9.1/webrick/httpserver.rb:94:in `run'
/home/bernd/.rvm/rubies/ruby-1.9.3-head/lib/ruby/1.9.1/webrick/server.rb:191:in `block in start_thread'
localhost - - [01/Sep/2011:13:13:53 CEST] "GET / HTTP/1.1" 500 374
- -> /
```
