### PR TITLE
Fix the webrick adapter for responses with a callable body.

### DIFF
--- a/lib/webmachine/adapters/webrick.rb
+++ b/lib/webmachine/adapters/webrick.rb
@@ -36,8 +36,10 @@ module Webmachine
             wres.body << response.body
           when Enumerable
             response.body.each {|part| wres.body << part }
-          when response.body.respond_to?(:call)
-            wres.body << response.body.call
+          else
+            if response.body.respond_to?(:call)
+              wres.body << response.body.call
+            end
           end
         end
       end


### PR DESCRIPTION
The case statement for `response.body` does not work with a proc like body.
