### PR TITLE
Make sure the correct response code is set in render_error.

### DIFF
--- a/lib/webmachine/errors.rb
+++ b/lib/webmachine/errors.rb
@@ -12,6 +12,7 @@ module Webmachine
   # @param [Hash] options keys to override the defaults when rendering
   #     the response body
   def self.render_error(code, req, res, options={})
+    res.code = code
     unless res.body
       title, message = t(["errors.#{code}.title", "errors.#{code}.message"],
                          { :method => req.method,

--- a/spec/webmachine/errors_spec.rb
+++ b/spec/webmachine/errors_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe "Webmachine errors" do
+  describe ".render_error" do
+    it "sets the given response code on the response object" do
+      req = double('request', :method => 'GET').as_null_object
+      res = Webmachine::Response.new
+
+      Webmachine.render_error(404, req, res)
+      res.code.should be(404)
+    end
+  end
+end


### PR DESCRIPTION
I noticed that the response code isn't set correctly if no route can be found in `Dispatcher.dispatch`. (it was 200 instead of 404)

So I added that to `Webmachine.render_error` but I'm not sure if that's desireable or if we should explicitly set it in `Dispatcher.dispatch` before/after calling `render_error`.
