### PR TITLE
minimal Rack adapter for pow/unicorn/etc compatibility

### DIFF
--- a/lib/webmachine/adapters/rack.rb
+++ b/lib/webmachine/adapters/rack.rb
@@ -1,0 +1,55 @@
+require 'rack/request'
+require 'webmachine/version'
+require 'webmachine/headers'
+require 'webmachine/request'
+require 'webmachine/response'
+require 'webmachine/dispatcher'
+
+# A minimal "shim" adapter to allow Webmachine to interface with Rack. The
+# intention here is to allow Webmachine to run under Rack-compatible
+# web-servers, like unicorn and pow, and is not intended to allow Webmachine
+# to be "plugged in" to an existin Rack app as middleware.
+#
+# To use this adapter, create a config.ru file and populate it like so:
+#
+#     require 'webmachine/adapters/rack'
+#
+#     # put your own Webmachine resources in another file:
+#     require 'my/resources'
+#
+#     run Webmachine::Adapters::Rack.new
+#
+# Servers like pow and unicorn will read config.ru by default and it should
+# all "just work".
+
+module Webmachine
+  module Adapters
+    class Rack
+      def call(env)
+        headers = Webmachine::Headers.new
+        env.each do |key, value|
+          if key =~ /^HTTP_/
+            key = $'.gsub(/_/, "-")
+            headers[key] = value
+          end
+        end
+        
+        rack_req = ::Rack::Request.new env
+        request = Webmachine::Request.new(rack_req.request_method,
+                    URI.parse(rack_req.url),
+                    headers,
+                    rack_req.body)
+
+        response = Webmachine::Response.new
+        Webmachine::Dispatcher.dispatch request, response
+
+        response.headers['Server'] = [Webmachine::SERVER_STRING, "Rack/#{::Rack.version}"].join(" ")
+
+        body = response.body.respond_to?(:call) ? response.body.call : response.body
+        body = body.is_a?(String) ? [ body ] : body
+
+        [response.code.to_i, response.headers, body || []]
+      end
+    end
+  end
+end

--- a/spec/webmachine/adapters/rack_spec.rb
+++ b/spec/webmachine/adapters/rack_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+require 'webmachine/adapters/rack'
+require 'rack'
+
+module Test
+  class Resource < Webmachine::Resource
+    def to_html
+      "<html><body>testing</body></html>"
+    end
+  end
+end
+
+describe Webmachine::Adapters::Rack do
+  let(:adapter) { described_class }
+
+  let(:env) do
+    { "REQUEST_METHOD"    => "GET",
+      "SCRIPT_NAME"       => "",
+      "PATH_INFO"         => "/test",
+      "QUERY_STRING"      => "",
+      "SERVER_NAME"       => "test.server",
+      "SERVER_PORT"       => 8080,
+      "rack.version"      => Rack::VERSION,
+      "rack.url_scheme"   => "http",
+      "rack.input"        => StringIO.new,
+      "rack.errors"       => StringIO.new,
+      "rack.multithread"  => false,
+      "rack.multiprocess" => true,
+      "rack.run_once"     => false }
+  end
+
+  before do
+    Webmachine::Dispatcher.reset
+    Webmachine::Dispatcher.add_route ['test'], Test::Resource
+  end
+
+  it "should proxy request to webmachine" do
+    code, headers, body = adapter.new.call(env)
+    code.should == 200
+    headers["Content-Type"].should == "text/html"
+    body.should include "<html><body>testing</body></html>"
+  end
+
+  it "should set Server header" do
+    code, headers, body = adapter.new.call(env)
+    headers.should have_key "Server"
+  end
+
+  it "should handle non-success correctly" do
+    env["PATH_INFO"] = "/missing"
+    code, headers, body = adapter.new.call(env)
+    code.should == 404
+    headers["Content-Type"].should == "text/html"
+  end
+
+  it "should handle empty bodies correctly" do
+    env["HTTP_ACCEPT"] = "application/json"
+    code, headers, body = adapter.new.call(env)
+    code.should == 406
+    headers.should_not have_key "Content-Type"
+    headers.should_not have_key "Content-Length"
+    body.should == []
+  end
+end


### PR DESCRIPTION
I know that Webmachine specifically states that it is not compatible with Rack, but it turned out to be very little work to create a rack adapter that wraps Webmachine. My goal was not to allow Webmachine to be plugged into an existing Rack app as middleware, but rather to allow Webmachine apps to run under rack-compatible servers like pow and unicorn. I've tested it with pow, specifically, and it works as advertised.
