### PR TITLE
Fixes Request.query to handle nil return value of uri.query

### DIFF
--- a/lib/webmachine/request.rb
+++ b/lib/webmachine/request.rb
@@ -55,7 +55,7 @@ module Webmachine
     def query
       unless @query
         @query = {}
-        uri.query.split(/&/).each do |kv|
+        (uri.query || '').split(/&/).each do |kv|
           k, v = CGI.unescape(kv).split(/=/)
           @query[k] = v if k && v
         end


### PR DESCRIPTION
When a URI doesn't contain '?', `URI.parse(...).query' will return nil, which breaks the querystring parser.
This changes Request.query to handle the case when uri.query returns nil.
