### PR TITLE
Stylistic changes

### DIFF
--- a/lib/webmachine/adapters/mongrel.rb
+++ b/lib/webmachine/adapters/mongrel.rb
@@ -74,7 +74,8 @@ module Webmachine
             response.body.close if response.body.respond_to? :close
           end
         end
-      end
-    end
-  end
-end
+      end # class Handler
+
+    end # module Mongrel
+  end # module Adapters
+end # module Webmachine

--- a/lib/webmachine/adapters/rack.rb
+++ b/lib/webmachine/adapters/rack.rb
@@ -45,6 +45,7 @@ module Webmachine
 
         [response.code.to_i, response.headers, body || []]
       end
-    end
-  end
-end
+    end # class Rack
+
+  end # module Adapters
+end # module Webmachine

--- a/lib/webmachine/adapters/webrick.rb
+++ b/lib/webmachine/adapters/webrick.rb
@@ -51,7 +51,7 @@ module Webmachine
             end
           end
         end
-      end
+      end # class Server
 
       # Wraps the WEBrick request body so that it can be passed to
       # {Request} while still lazily evaluating the body.
@@ -79,7 +79,8 @@ module Webmachine
             @request.body {|chunk| @value << chunk; yield chunk }
           end
         end
-      end
-    end
-  end
-end
+      end # class RequestBody
+
+    end # module WEBrick
+  end # module Adapters
+end # module Webmachine

--- a/lib/webmachine/chunked_body.rb
+++ b/lib/webmachine/chunked_body.rb
@@ -39,5 +39,5 @@ module Webmachine
       end
       yield(FINAL_CHUNK)
     end
-  end
-end
+  end # class ChunkedBody
+end # module Webmachine

--- a/lib/webmachine/configuration.rb
+++ b/lib/webmachine/configuration.rb
@@ -26,5 +26,4 @@ module Webmachine
     yield @configuration if block_given?
     self
   end
-end
-  
+end # module Webmachine

--- a/lib/webmachine/decision/conneg.rb
+++ b/lib/webmachine/decision/conneg.rb
@@ -233,6 +233,7 @@ module Webmachine
           raise MalformedRequest, t('invalid_media_type', :type => c)
         end
       end
-    end
-  end
-end
+
+    end # module Conneg
+  end # module Decision
+end # module Webmachine

--- a/lib/webmachine/decision/flow.rb
+++ b/lib/webmachine/decision/flow.rb
@@ -497,6 +497,7 @@ module Webmachine
       def p11
         !response.headers["Location"] ? :o20 : 201
       end
-    end
-  end
-end
+
+    end # module Flow
+  end # module Decision
+end # module Webmachine

--- a/lib/webmachine/decision/fsm.rb
+++ b/lib/webmachine/decision/fsm.rb
@@ -64,6 +64,7 @@ module Webmachine
         Webmachine.render_error(500, request, response)
         respond(500)
       end
-    end
-  end
-end
+
+    end # class FSM
+  end # module Decision
+end # module Webmachine

--- a/lib/webmachine/decision/helpers.rb
+++ b/lib/webmachine/decision/helpers.rb
@@ -99,6 +99,6 @@ module Webmachine
           response.headers['Last-Modified'] = modified.httpdate
         end
       end
-    end
-  end
-end
+    end # module Helpers
+  end # module Decision
+end # module Webmachine

--- a/lib/webmachine/dispatcher.rb
+++ b/lib/webmachine/dispatcher.rb
@@ -64,4 +64,4 @@ module Webmachine
     Dispatcher.instance.instance_eval(&block)
     self
   end
-end
+end # module Webmachine

--- a/lib/webmachine/dispatcher/route.rb
+++ b/lib/webmachine/dispatcher/route.rb
@@ -84,6 +84,7 @@ module Webmachine
           depth += 1
         end
       end
-    end
-  end
-end
+
+    end # class Route
+  end # module Dispatcher
+end # module Webmachine

--- a/lib/webmachine/errors.rb
+++ b/lib/webmachine/errors.rb
@@ -35,4 +35,4 @@ module Webmachine
   # the case where a request header is improperly formed. Raising this
   # exception will result in a 400 response.
   class MalformedRequest < Error; end
-end
+end # module Webmachine

--- a/lib/webmachine/headers.rb
+++ b/lib/webmachine/headers.rb
@@ -36,5 +36,5 @@ module Webmachine
     def transform_key(key)
       key.to_s.downcase
     end
-  end
-end
+  end # class Headers
+end # module Webmachine

--- a/lib/webmachine/media_type.rb
+++ b/lib/webmachine/media_type.rb
@@ -116,5 +116,5 @@ module Webmachine
         other.major == major && other.minor == "*"
       end
     end
-  end
-end
+  end # class MediaType
+end # module Webmachine

--- a/lib/webmachine/request.rb
+++ b/lib/webmachine/request.rb
@@ -62,5 +62,5 @@ module Webmachine
       end
       @query
     end
-  end
-end
+  end # class Request
+end # module Webmachine

--- a/lib/webmachine/resource.rb
+++ b/lib/webmachine/resource.rb
@@ -45,5 +45,6 @@ module Webmachine
     def charset_nop(x)
       x
     end
-  end
-end
+
+  end # class Resource
+end # module Webmachine

--- a/lib/webmachine/resource/authentication.rb
+++ b/lib/webmachine/resource/authentication.rb
@@ -30,6 +30,7 @@ module Webmachine
           %Q[Basic realm="#{realm}"]
         end
       end
-    end
-  end
-end
+
+    end # module Authentication
+  end # class Resource
+end # module Webmachine

--- a/lib/webmachine/resource/callbacks.rb
+++ b/lib/webmachine/resource/callbacks.rb
@@ -371,6 +371,7 @@ module Webmachine
       def validate_content_checksum
         nil
       end
-    end
-  end
-end
+
+    end # module Callbacks
+  end # class Resource
+end # module Webmachine

--- a/lib/webmachine/resource/encodings.rb
+++ b/lib/webmachine/resource/encodings.rb
@@ -31,6 +31,7 @@ module Webmachine
           Zlib::GzipWriter.wrap(StringIO.new(out)){|gz| gz << data }
         end
       end
-    end
-  end
-end
+
+    end # module Encodings
+  end # class Resource
+end # module Webmachine

--- a/lib/webmachine/response.rb
+++ b/lib/webmachine/response.rb
@@ -46,5 +46,6 @@ module Webmachine
 
     alias :is_redirect? :redirect
     alias :redirect_to :do_redirect
-  end
-end
+
+  end # class Response
+end # module Webmachine

--- a/lib/webmachine/streaming.rb
+++ b/lib/webmachine/streaming.rb
@@ -26,7 +26,7 @@ module Webmachine
         yield resource.send(encoder, resource.send(charsetter, block.to_s))
       end
     end
-  end
+  end # class EnumerableEncoder
 
   # Implements a streaming encoder for callable bodies, such as
   # Proc. (essentially futures)
@@ -44,7 +44,7 @@ module Webmachine
     def to_proc
       method(:call).to_proc
     end
-  end
+  end # class CallableEncoder
 
   # Implements a streaming encoder for Fibers with the same API as the
   # EnumerableEncoder. This will resume the Fiber until it terminates
@@ -59,5 +59,5 @@ module Webmachine
         yield resource.send(encoder, resource.send(charsetter, chunk.to_s))
       end
     end
-  end
-end
+  end # class FiberEncoder
+end # module Webmachine


### PR DESCRIPTION
Here are a couple of stylistic changes. The annotated `end` keywords are clearly a matter of taste, but I find it helpful when navigating nested modules. The implicit exception handling scope of method definition is always better, in my view; hopefully you agree :).
