### PR TITLE
Skip mongrel adapter spec on jruby

### DIFF
--- a/spec/webmachine/adapters/mongrel_spec.rb
+++ b/spec/webmachine/adapters/mongrel_spec.rb
@@ -1,5 +1,10 @@
 require "spec_helper"
 
+if RUBY_PLATFORM =~ /java/
+  warn "Platform is #{RUBY_PLATFORM}: skipping mongrel adapter spec."
+  return
+end
+
 describe Webmachine::Adapters::Mongrel do
   let(:configuration) { Webmachine::Configuration.default }
   let(:dispatcher) { Webmachine::Dispatcher.new }


### PR DESCRIPTION
This should fix the failure on travis-ci. Looks like I introduced it by adding the Mongrel adapter spec, which is autoloaded and previously not loaded on jruby.
