### PR TITLE
Route accepts optional list of guard blocks

### DIFF
--- a/spec/webmachine/dispatcher/route_spec.rb
+++ b/spec/webmachine/dispatcher/route_spec.rb
@@ -37,6 +37,50 @@ describe Webmachine::Dispatcher::Route do
       it { should_not match_route [] }
       it { should_not match_route %w{bar *} }
     end
+
+    context "with a guard on the request method" do
+      let(:route) do
+        described_class.new(
+          ["notes"],
+          lambda { |request| request.method == "POST" },
+          resource
+        )
+      end
+
+      before do
+        request.uri.path = "/notes"
+      end
+
+      context "when guard returns true" do
+        before do
+          request.method.replace "POST"
+        end
+
+        it "returns true" do
+          route.match?(request).should be_true
+        end
+
+        context "but the path match fails" do
+          before do
+            request.uri.path = "/other"
+          end
+
+          it "returns false" do
+            route.match?(request).should be_false
+          end
+        end
+      end
+
+      context "when guard returns false" do
+        before do
+          request.method.replace "GET"
+        end
+
+        it "returns false" do
+          route.match?(request).should be_false
+        end
+      end
+    end
   end
 
   context "applying bindings" do


### PR DESCRIPTION
This feature brings the routing features in line with that of the erlang version. Thus, the following:

``` erlang
%% https://github.com/basho/riak_kv/blob/master/src/riak_kv_web.erl
[
  {["buckets", bucket, "keys"], fun is_post/1,
    riak_kv_wm_object, Props2},

  {["buckets", bucket, "keys"],
    riak_kv_wm_keylist, Props2},

  {["buckets", bucket, "keys", key],
    riak_kv_wm_object, Props2}
].
```

Becomes:

``` ruby
Webmachine.application.routes do
  add ["buckets", :bucket, "keys"],
    ->(r) { r.method == "POST" },
    Riak::KV::WM::Object
  add ["buckets", :bucket, "keys"], Riak::KV::WM::KeyList
  add ["buckets", :bucket, "keys", :key], Riak::KV::WM::Object
end
```
