### PR TITLE
Resource#create_path is optional if Location is set

### DIFF
--- a/lib/webmachine/decision/flow.rb
+++ b/lib/webmachine/decision/flow.rb
@@ -401,17 +401,21 @@ module Webmachine
       def n11
         # Stage1
         if resource.post_is_create?
-          case uri = resource.create_path
-          when nil
+          uri = resource.create_path
+
+          result = accept_helper
+          return result if Fixnum === result
+
+          uri ||= response.headers['Location']
+
+          unless uri
             raise InvalidResource, t('create_path_nil', :class => resource.class)
-          when URI, String
-            base_uri = resource.base_uri || request.base_uri
-            new_uri = URI.join(base_uri.to_s, uri)
-            request.disp_path = new_uri.path
-            response.headers['Location'] = new_uri.to_s
-            result = accept_helper
-            return result if Fixnum === result
           end
+
+          base_uri = resource.base_uri || request.base_uri
+          new_uri = URI.join(base_uri.to_s, uri)
+          request.disp_path = new_uri.path
+          response.headers['Location'] = new_uri.to_s
         else
           case result = resource.process_post
           when true


### PR DESCRIPTION
Consider this a proposal --

This introduces a slight change to the semantics in the processing of a
request when `#post_is_create?` returns true, adding support for
environments where `create_path` cannot be determined before processing
the request.

Thus, an implementor using MongoDB can do:

```
class MyResource
  def create_path
    request.path_info[:id] = BSON::ObjectId.new
    "/resources/#{request.path_info[:id]}"
  end
end
```

While an implementor using Postgres might do:

```
class MyResource
  def create_path() nil end
  def accept_json
    resource = Resource.create
    response.headers['Location'] = "/resources/#{resource.id}"
    true
  end
end
```

Additionally, the response header's location is only set after the
accept handler has run, in case the handler fails for some other reason
(such as an incorrect content type).

With this feature and the feature guard feature #25, I'm able to get the following (very pleasing!) behavior: https://gist.github.com/1600780
