### PR TITLE
Problem with whitespace in Accept-Encoding header

### DIFF
--- a/lib/webmachine/decision/conneg.rb
+++ b/lib/webmachine/decision/conneg.rb
@@ -97,7 +97,7 @@ module Webmachine
       # @api private
       def do_choose(choices, header, default)
         choices = choices.dup.map {|s| s.downcase }
-        accepted = PriorityList.build(header.split(/\s*,\s/))
+        accepted = PriorityList.build(header.split(/\s*,\s*/))
         default_priority = accepted.priority_of(default)
         star_priority = accepted.priority_of("*")
         default_ok = (default_priority.nil? && star_priority != 0.0) || default_priority

--- a/spec/webmachine/decision/conneg_spec.rb
+++ b/spec/webmachine/decision/conneg_spec.rb
@@ -74,6 +74,13 @@ describe Webmachine::Decision::Conneg do
       response.headers['Content-Encoding'].should == 'gzip'
     end
 
+    it "should choose the first acceptable encoding" \
+       ", even when no white space after comma" do
+      subject.choose_encoding({"gzip" => :encode_gzip}, "identity,gzip")
+      subject.metadata['Content-Encoding'].should == 'gzip'
+      response.headers['Content-Encoding'].should == 'gzip'
+    end
+
     it "should choose the preferred encoding over less-preferred encodings" do
       subject.choose_encoding({"gzip" => :encode_gzip, "identity" => :encode_identity}, "gzip, identity;q=0.7")
       subject.metadata['Content-Encoding'].should == 'gzip'


### PR DESCRIPTION
I have the following problem:

The google-chrome browser (Version 18.0.1025.162) sends the request header
  Accept-Encoding:gzip,deflate,sdch
There is no whitespace after the comma. Therefore webmachine does not recognize the gzip encoding when a resource provides it. According to the HTTP 1.1 spec the whitespace around commas in lists is optional.

I think that with the included commit I have solved the problem.
