### PR TITLE
Update to current Reel API

### DIFF
--- a/lib/webmachine/adapters/reel.rb
+++ b/lib/webmachine/adapters/reel.rb
@@ -33,14 +33,7 @@ module Webmachine
           response = Webmachine::Response.new
           @dispatcher.dispatch(request,response)
 
-          wres = case response.body
-          when String
-            ::Reel::Response.new(response.code, response.headers, response.body)
-          when Enumerable
-            ::Reel::StreamingResponse.new(response.code, response.headers, response.body)
-          end
-
-          connection.respond(wres)
+          connection.respond ::Reel::Response.new(response.code, response.headers, response.body)
         end
       end
     end


### PR DESCRIPTION
Reel now natively supports streaming Enumerables as Transfer-Encoding: chunked, and the StreamingResponse API has been removed.

This updates the Reel adapter to the newer, simpler API.
