### PR TITLE
Make the Dispatcher#resource_creator an attr_accessor, so it can be deco...

### DIFF
--- a/lib/webmachine/dispatcher.rb
+++ b/lib/webmachine/dispatcher.rb
@@ -11,10 +11,10 @@ module Webmachine
     # @see #add_route
     attr_reader :routes
 
-    # Set the creator for resource used to process requests.
-    # Must respond to call(request, response) and return
+    # The creator for resources used to process requests.
+    # Must respond to call(route, request, response) and return
     # a newly created resource instance.
-    attr_writer :resource_creator
+    attr_accessor :resource_creator
 
     # Initialize a Dispatcher instance
     # @param resource_creator Invoked to create resource instances.


### PR DESCRIPTION
...rated/wrapped.

One more minor change, that will let folks do something like:

```
app = Webmachine::Application.new do |a|
  orig_creator = a.dispatcher.resource_creator
  a.dispatcher.resource_creator = lambda { |resource, req, resp|
    orig_creator.call (resource, req, resp).tap { |r| r.application = a }
  }
end
```

to decorate/wrap the original creator with additional functionality.
