### PR TITLE
Initial work on accepting the content for a POST before retrieving the c...

### DIFF
--- a/lib/webmachine/decision/flow.rb
+++ b/lib/webmachine/decision/flow.rb
@@ -401,6 +401,9 @@ module Webmachine
       def n11
         # Stage1
         if resource.post_is_create?
+          result = accept_helper
+          return result if Fixnum === result
+
           case uri = resource.create_path
           when nil
             raise InvalidResource, t('create_path_nil', :class => resource.class)
@@ -409,8 +412,6 @@ module Webmachine
             new_uri = URI.join(base_uri.to_s, uri)
             request.disp_path = new_uri.path
             response.headers['Location'] = new_uri.to_s
-            result = accept_helper
-            return result if Fixnum === result
           end
         else
           case result = resource.process_post

--- a/spec/webmachine/decision/flow_spec.rb
+++ b/spec/webmachine/decision/flow_spec.rb
@@ -806,7 +806,7 @@ describe Webmachine::Decision::Flow do
         def create_path; @new_loc; end
         def content_types_accepted; [["text/plain", :accept_text]]; end
         def accept_text
-          response.headers['Location'] = @new_loc.to_s if @new_loc
+          response.headers['Location'] = @new_loc.to_s if @new_loc && !@create
           true
         end
       end
@@ -846,7 +846,7 @@ describe Webmachine::Decision::Flow do
             resource.create = true
             subject.run
             response.code.should == 201
-            response.headers['Location'].should == created
+            response.headers['Location'].should be_end_with created
           end
           it "should reply with 500 when post_is_create is true and create_path returns nil" do
             resource.create = true


### PR DESCRIPTION
...reate_path for the new Location header value.

Not sure if this change really is valid or not. Using this PR to get some clarity one way or another.

When using post_is_create? with a value of true, Decision::Flow will query the "create_path" _before_ accepting the sent input type. For cases where processing the input creates a new resource, it's likely that the new create_path is not known until after saving some data to the database. With the current logic, you would need to put a dummy path for the response to "create_path", and then set the request.headers['Location'] yourself in the accept method.

Before:

```
class OrderResource
  def post_is_create?
    true
  end

  def create_path
    "/orders/fake"
  end

  def content_types_accepted
    ['application/x-www-urlencoded', :accept_urlencoded]
  end

  def accept_urlencoded
    order = Order.from_urlencoded(request.body)
    order.save!
    response.headers['Location'] = "/orders/#{order.id}"
  end
end
```

With this change:

```
class OrderResource
  def post_is_create?
    true
  end

  def create_path
    "/orders/#{@order.id}"
  end

  def content_types_accepted
    ['application/x-www-urlencoded', :accept_urlencoded]
  end

  def accept_urlencoded
    @order = Order.from_urlencoded(request.body)
    @order.save!
  end
end
```

Am I misunderstanding the intended use of `create_path` and `content_types_accepted`?
