### PR TITLE
Switch to using open w/ the binary option, to ensure the static/map.png ...

### DIFF
--- a/lib/webmachine/trace/trace_resource.rb
+++ b/lib/webmachine/trace/trace_resource.rb
@@ -73,7 +73,7 @@ module Webmachine
         # TODO: Add support for IO objects as response bodies,
         # allowing server optimizations like sendfile or chunked
         # downloads
-        File.read(@file)
+        open(@file, "rb") {|io| io.read }
       end
 
       def produce_list


### PR DESCRIPTION
...resource reads properly on Windows.

Just using `File::read` on Windows causes the file to be read improperly. The solution used was based on the suggestion found here: http://blog.leosoto.com/2008/03/reading-binary-file-on-ruby.html

If you'd prefer a different approach for properly reading the binary file, I'm happy to change this.

Thanks.
