### PR TITLE
Add optional body for OPTIONS method

### DIFF
--- a/lib/webmachine/resource/callbacks.rb
+++ b/lib/webmachine/resource/callbacks.rb
@@ -110,12 +110,20 @@ module Webmachine
       end
 
       # If the OPTIONS method is supported and is used, this method
-      # should return a Hash of headers that should appear in the
-      # response. Defaults to {}.
-      # @return [Hash] headers to appear in the response
+      # should return an array with two items: a Hash of headers that
+      # should appear in the response and an array of pairs where each pair is of the
+      # form [mediatype, :handler] where mediatype is a String of
+      # Content-Type format (or {Webmachine::MediaType}) and :handler
+      # is a Symbol naming the method which can provide a resource
+      # representation in that media type. For example, if a client
+      # request includes an 'Accept' header with a value that does not
+      # appear as a first element in any of the return pairs, then a
+      # '406 Not Acceptable' will be sent.
+      # Defaults to [{}, [['text/plain', :to_options]]]
+      # @return [Array] headers and
       # @api callback
       def options
-        {}
+        [{}, [['text/plain', :to_options]]]
       end
 
       # HTTP methods that are allowed on this resource. This must return

--- a/spec/webmachine/decision/flow_spec.rb
+++ b/spec/webmachine/decision/flow_spec.rb
@@ -261,10 +261,28 @@ describe Webmachine::Decision::Flow do
 
   describe "#b3 (OPTIONS?)" do
     let(:method){ "OPTIONS" }
-    let(:resource){ resource_with { def allowed_methods; %w[GET HEAD OPTIONS]; end } }
+    let(:resource) do
+      resource_with do
+        def allowed_methods
+          %w[GET HEAD OPTIONS]
+        end
+        def to_options
+          "Plain text"
+        end
+      end
+    end
+
     it "should reply with 200 when the request method is OPTIONS" do
       subject.run
       response.code.should == 200
+    end
+
+    context "optional response body" do
+      it "should include a response body if given" do
+        subject.run
+        response.body.should_not be_nil
+        response.body.should match(/Plain text/)
+      end
     end
   end
 


### PR DESCRIPTION
Section 9.2 of RFC 2616 provides for an optional response body in the OPTIONS method. Section 9.2 further provides that the response body, if any, SHOULD include information about the communication options. The format for such a body is not defined by the specification, but might be defined by future extensions to HTTP. Content negotiation MAY be used to select the appropriate response format. If no response body is included, the response MUST include a Content-Length field with a field-value of "0".

At REST Fest 2012, one of the presenters used the OPTIONS method to provide additional information to API clients in the response body. I tried to implement similar functionality with Webmachine, but could not because the `options` callback only allowed a `Hash` of headers.

I changed the `options` callback to return an Array of two items: a Hash of headers and an array of Content-Type and handler pairs, similar to the `content_types_provided` callback.
