### PR TITLE
Unbreak CI for JRuby 1.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,9 @@ gem 'bundler'
 
 group :webservers do
   gem 'mongrel',  '~> 1.2.beta', :platform => [:mri, :rbx]
-  gem 'reel',     '>= 0.1.0', :platform => [:ruby_19, :jruby]
+  if RUBY_VERSION >= '1.9'
+    gem 'reel',   '>= 0.1.0', :platform => [:ruby_19, :jruby]
+  end
   gem 'hatetepe', '~> 0.5'
 end
 


### PR DESCRIPTION
This should fix the Travis jruby-18mode which has been broken since the pull request #51.

It's not really nice but I don't see any other way. Okay to merge?
