### PR TITLE
Turn decision_test on its head so conventionally truthy values (like an ...

### DIFF
--- a/lib/webmachine/decision/flow.rb
+++ b/lib/webmachine/decision/flow.rb
@@ -29,12 +29,12 @@ module Webmachine
       # Handles standard decisions where halting is allowed
       def decision_test(test, value, iftrue, iffalse)
         case test
-        when value
-          iftrue
         when Fixnum # Allows callbacks to "halt" with a given response code
           test
-        else
+        when !value
           iffalse
+        else
+          iftrue
         end
       end
 

--- a/spec/webmachine/decision/flow_spec.rb
+++ b/spec/webmachine/decision/flow_spec.rb
@@ -414,6 +414,12 @@ describe Webmachine::Decision::Flow do
       subject.run
       response.code.should_not == 404
     end
+
+    it "should not reply with 404 for truthy non-booleans" do
+      resource.exist = []
+      subject.run
+      response.code.should_not == 404
+    end
   end
 
   # Conditional requests/preconditions


### PR DESCRIPTION
...array or collection or object) will pass

Example: I write lots of stuff like

```
  def resource_exists?
    @resource = Resource.find(...)
    @resource.present?   # Would like to dispense with this line, as @resource is not nil or false
  end
```
