### PR TITLE
Commit the trace to storage after the response has been traced.

### DIFF
--- a/lib/webmachine/trace/fsm.rb
+++ b/lib/webmachine/trace/fsm.rb
@@ -16,7 +16,8 @@ module Webmachine
         }
       end
 
-      # Adds the response to the trace.
+      # Adds the response to the trace and then commits the trace to
+      # separate storage which can be discovered by the debugger.
       # @param [Webmachine::Response] response the response to be traced
       def trace_response(response)
         response.trace << {
@@ -25,6 +26,8 @@ module Webmachine
           :headers => response.headers,
           :body => trace_response_body(response.body)
         }
+      ensure
+        Trace.record(resource.object_id.to_s, response.trace)
       end
 
       # Adds a decision to the trace.

--- a/lib/webmachine/trace/resource_proxy.rb
+++ b/lib/webmachine/trace/resource_proxy.rb
@@ -35,14 +35,12 @@ module Webmachine
         proxy_callback :charset_nop, *args
       end
 
-      # Calls the resource's finish_request method and then commits
-      # the trace to separate storage which can be discovered by the
-      # debugger.
+      # Calls the resource's finish_request method and then sets the trace id
+      # header in the response.
       def finish_request(*args)
         proxy_callback :finish_request, *args
       ensure
         resource.response.headers['X-Webmachine-Trace-Id'] = object_id.to_s
-        Trace.record(object_id.to_s, resource.response.trace)
       end
 
       private

--- a/spec/webmachine/trace/fsm_spec.rb
+++ b/spec/webmachine/trace/fsm_spec.rb
@@ -18,6 +18,11 @@ describe Webmachine::Trace::FSM do
       response.trace.should_not be_empty
       Webmachine::Trace.traces.should have(1).item
     end
+
+    it "commits the trace to separate storage when the request has finished processing" do
+      Webmachine::Trace.should_receive(:record).with(subject.resource.object_id.to_s, response.trace).and_return(true)
+      subject.run
+    end
   end
 
   context "when tracing is disabled" do

--- a/spec/webmachine/trace/resource_proxy_spec.rb
+++ b/spec/webmachine/trace/resource_proxy_spec.rb
@@ -27,9 +27,7 @@ describe Webmachine::Trace::ResourceProxy do
     response.trace[-1].should == {:type => :result, :value => "<html><body>Hello, world!</body></html>"}
   end
 
-  it "commits the trace to separate storage when the request has finished processing" do
-    Webmachine::Trace.should_receive(:record).with(subject.object_id.to_s, [{:type=>:attempt, :name=>"(default)#finish_request"},
-                                                                       {:type=>:result, :value=>nil}]).and_return(true)
+  it "sets the trace id header when the request has finished processing" do
     subject.finish_request
     response.headers["X-Webmachine-Trace-Id"].should == subject.object_id.to_s
   end


### PR DESCRIPTION
Not sure if it was intentional to not include the response in the stored trace but I think it's nice to have the response stored as well. :)
