### PR TITLE
Set response code before calling finish_request.

### DIFF
--- a/lib/webmachine/decision/fsm.rb
+++ b/lib/webmachine/decision/fsm.rb
@@ -54,6 +54,7 @@ module Webmachine
       end
 
       def respond(code, headers={})
+        response.code = code
         response.headers.merge!(headers)
         case code
         when 404

--- a/spec/webmachine/decision/fsm_spec.rb
+++ b/spec/webmachine/decision/fsm_spec.rb
@@ -66,4 +66,24 @@ describe Webmachine::Decision::FSM do
       subject.run
     end
   end
+
+  it "sets the response code before calling finish_request" do
+    resource_class.class_eval do
+      class << self
+        attr_accessor :current_response_code
+      end
+
+      def to_html
+        201
+      end
+
+      def finish_request
+        self.class.current_response_code = response.code
+      end
+    end
+
+    subject.run
+
+    resource_class.current_response_code.should be(201)
+  end
 end


### PR DESCRIPTION
This behaviour was changed in commit 37f4ed3.

@lgierth I guess that was not intentional?
