### PR TITLE
Allow resource duck typing

### DIFF
--- a/lib/webmachine/dispatcher/route.rb
+++ b/lib/webmachine/dispatcher/route.rb
@@ -69,8 +69,6 @@ module Webmachine
         @guards    = guards
         @resource  = resource
         @bindings  =  bindings
-
-        raise ArgumentError, t('not_resource_class', :class => resource.name) unless resource < Resource
       end
 
       # Determines whether the given request matches this route and


### PR DESCRIPTION
Remove router requirement that resources be Webmachine::Resource subclasses.

See: https://gist.github.com/4509675
