### PR TITLE
Streaming in Rack adapter

### DIFF
--- a/spec/webmachine/adapters/rack_spec.rb
+++ b/spec/webmachine/adapters/rack_spec.rb
@@ -160,3 +160,25 @@ describe Webmachine::Adapters::Rack do
     last_response.body.split("\r\n").should == %W{6 Stream 0}
   end
 end
+
+describe Webmachine::Adapters::Rack::RackResponse do
+  context "on Rack < 1.5 release" do
+    before { Rack.stub(:release => "1.4") }
+
+    it "should add Content-Type header on not acceptable response" do
+      rack_response = described_class.new(double(:body), 406, {})
+      rack_status, rack_headers, rack_body = rack_response.finish
+      rack_headers.should have_key("Content-Type")
+    end
+  end
+
+  context "on Rack >= 1.5 release" do
+    before { Rack.stub(:release => "1.5") }
+
+    it "should not add Content-Type header on not acceptable response" do
+      rack_response = described_class.new(double(:body), 406, {})
+      rack_status, rack_headers, rack_body = rack_response.finish
+      rack_headers.should_not have_key("Content-Type")
+    end
+  end
+end


### PR DESCRIPTION
Looks like I broke streaming support in Rack adapter in https://github.com/seancribbs/webmachine-ruby/commit/41fb3885d1d216e91cf29d3c60dd24da5c146912. 

But first a little background. The intention of `Rack::Response` wrapping was to let Rack do the cleanup regarding `Content-Type`, e.g. for https://github.com/seancribbs/webmachine-ruby/commit/f33677849d0c1cad8362a625d17447b87fe56289. This `Content-Type` requirement has changed in latest releases but wrapping did always the right cleanup for particular release. Original PR is here https://github.com/seancribbs/webmachine-ruby/pull/68.

I did not notice that `Rack::Response` iterates over given body https://github.com/rack/rack/blob/master/lib/rack/response.rb#L35-L38 which in some cases (when enumerable could not be exhausted) blocked responding to client. Until I realized that I've started fixing streaming with hijacking https://github.com/seancribbs/webmachine-ruby/commit/b7322f9f8881a6451a1bc340f4af689692f5fe17.

Now it seems it's best to revert `Rack::Response` and backport its `Content-Type` cleanups satisfying `Rack::Lint` for several Rack releases to adapter. I would love to know your opinion on this.
