### PR TITLE
Reel adapter fixups

### DIFF
--- a/lib/webmachine/adapters/reel.rb
+++ b/lib/webmachine/adapters/reel.rb
@@ -4,48 +4,84 @@ require 'webmachine/headers'
 require 'webmachine/request'
 require 'webmachine/response'
 require 'webmachine/dispatcher'
-require 'webmachine/chunked_body'
+require 'set'
 
 module Webmachine
   module Adapters
     class Reel < Adapter
       def run
-        options = {
+        @options = {
           :port => configuration.port,
           :host => configuration.ip
         }.merge(configuration.adapter_options)
 
-        server = ::Reel::Server.supervise(options[:host], options[:port], &method(:process))
-        trap("INT"){ server.terminate; exit 0 }
-        sleep
+        if extra_verbs = configuration.adapter_options[:extra_verbs]
+          @extra_verbs = Set.new(extra_verbs.map(&:to_s).map(&:upcase))
+        else
+          @extra_verbs = Set.new
+        end
+
+        server = ::Reel::Server.supervise(@options[:host], @options[:port], &method(:process))
+
+        # FIXME: this will no longer work on Ruby 2.0. We need Celluloid.trap
+        trap("INT") { server.terminate; exit 0 }
+        Celluloid::Actor.join(server)
       end
 
       def process(connection)
-        while wreq = connection.request
-          case wreq
-          when ::Reel::Request
-            header = Webmachine::Headers[wreq.headers.dup]
-            host_parts = header.fetch('Host').split(':')
-            path_parts = wreq.url.split('?')
-            requri = URI::HTTP.build({}.tap do |h|
-              h[:host] = host_parts.first
-              h[:port] = host_parts.last.to_i if host_parts.length == 2
-              h[:path] = path_parts.first
-              h[:query] = path_parts.last if path_parts.length == 2
-            end)
-            request = Webmachine::Request.new(wreq.method.to_s.upcase,
-                                              requri,
-                                              header,
-                                              LazyRequestBody.new(wreq))
-            response = Webmachine::Response.new
-            @dispatcher.dispatch(request,response)
+        while request = connection.request
+          # Users of the adapter can configure a custom WebSocket handler
+          if request.is_a? ::Reel::WebSocket
+            if handler = @options[:websocket_handler]
+              handler.call(request)
+            else
+              # Pretend we don't know anything about the WebSocket protocol
+              # FIXME: This isn't strictly what RFC 6455 would have us do
+              request.respond :bad_request, "WebSockets not supported"
+            end
 
-            connection.respond ::Reel::Response.new(response.code, response.headers, response.body)
-          when ::Reel::WebSocket
-            handler = configuration.adapter_options[:websocket_handler]
-            handler.call(wreq) if handler
+            next
+          end
+
+          # Optional support for e.g. WebDAV verbs not included in Webmachine's
+          # state machine. Do the "Railsy" thing and handle them like POSTs
+          # with a magical parameter
+          if @extra_verbs.include?(request.method)
+            method = "POST"
+            param  = "_method=#{request.method}"
+            uri    = request_uri(request.url, request.headers, param)
+          else
+            method = request.method
+            uri    = request_uri(request.url, request.headers)
+          end
+
+          wm_headers  = Webmachine::Headers[request.headers.dup]
+          wm_request  = Webmachine::Request.new(method, uri, wm_headers, request.body)
+          wm_response = Webmachine::Response.new
+          @dispatcher.dispatch(wm_request, wm_response)
+
+          request.respond ::Reel::Response.new(wm_response.code, wm_response.headers, wm_response.body)
+        end
+      end
+
+      def request_uri(path, headers, extra_query_params = nil)
+        host_parts = headers.fetch('Host').split(':')
+        path_parts = path.split('?')
+
+        uri_hash = {host: host_parts.first, path: path_parts.first}
+
+        uri_hash[:port]  = host_parts.last.to_i if host_parts.length == 2
+        uri_hash[:query] = path_parts.last      if path_parts.length == 2
+
+        if extra_query_params
+          if uri_hash[:query]
+            uri_hash[:query] << "&#{extra_query_params}"
+          else
+            uri_hash[:query] = extra_query_params
           end
         end
+
+        URI::HTTP.build(uri_hash)
       end
     end
   end


### PR DESCRIPTION
This is a snapshot of the Reel adapter I'm using in the Cryptosphere.

It includes some general refactoring and the following notable changes:
- Support for mapping extended HTTP verbs to the _method pseudoparameter (e.g.
  for WebDAV support)
- Joins to the foreground actor rather than sleeping the thread. This fixes
  deadlock detection issues
- Streaming support: passes Reel's request.body objects through unmolested
  rather than using LazyRequestBody
