### PR TITLE
Lock Reel version to 0.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :webservers do
   gem 'mongrel',  '~> 1.2.beta', :platform => [:mri, :rbx]
 
   if RUBY_VERSION >= '1.9'
-    gem 'reel', '>= 0.1.0', :platform => [:ruby_19, :ruby_20, :jruby]
+    gem 'reel', '~> 0.3.0', :platform => [:ruby_19, :ruby_20, :jruby]
   end
 
   gem 'hatetepe', '~> 0.5'


### PR DESCRIPTION
Reel 0.4.0 (unreleased) contains breaking API changes. Locking to 0.3.0 will ensure
that the existing tests continue to pass until the adapter itself can be
updated to the new API.
