### PR TITLE
Invalid missing resource response on non-existent route.

### DIFF
--- a/spec/webmachine/dispatcher_spec.rb
+++ b/spec/webmachine/dispatcher_spec.rb
@@ -69,4 +69,11 @@ describe Webmachine::Dispatcher do
     fsm.should_receive(:run)
     dispatcher.dispatch(request, response)
   end
+
+  it "should respond with valid resource missing response for request to non-existing route" do
+    dispatcher.dispatch(request, response)
+    response.code.should     eq(404)
+    response.body.should_not be_empty
+    response.headers.should  have_key('Content-Length')
+  end
 end


### PR DESCRIPTION
While working on new adapter for webmachine I have noticed one case where there's a 404 response returned with body without Content-Length. This case happens to be an early check whether route for requested resource exists:
https://github.com/seancribbs/webmachine-ruby/blob/master/lib/webmachine/dispatcher.rb#L50-L52

It doesn't go through FSM where this case is already covered:
https://github.com/seancribbs/webmachine-ruby/blob/master/lib/webmachine/decision/fsm.rb#L60-L72

It went unnoticed because I guess most webservers fix that header for misbehaving frameworks and the one I'm writing adapter for does not. I need some guidance where's the best place to fix this. Also reusing `set_content_length` would be nice but it currently relies on accessors:
https://github.com/seancribbs/webmachine-ruby/blob/master/lib/webmachine/decision/helpers.rb#L114-L120
