### PR TITLE
Removed duplicate require in Reel Adapter

### DIFF
--- a/lib/webmachine/adapters/reel.rb
+++ b/lib/webmachine/adapters/reel.rb
@@ -4,17 +4,19 @@ require 'webmachine/headers'
 require 'webmachine/request'
 require 'webmachine/response'
 require 'webmachine/dispatcher'
-require 'webmachine/adapters/lazy_request_body'
 require 'set'
 
 module Webmachine
   module Adapters
     class Reel < Adapter
+      # Used to override default Reel server options (useful in testing)
+      DEFAULT_OPTIONS = {}
+      
       def run
-        @options = {
+        @options = DEFAULT_OPTIONS.merge({
           :port => configuration.port,
           :host => configuration.ip
-        }.merge(configuration.adapter_options)
+        }).merge(configuration.adapter_options)
 
         if extra_verbs = configuration.adapter_options[:extra_verbs]
           @extra_verbs = Set.new(extra_verbs.map(&:to_s).map(&:upcase))


### PR DESCRIPTION
Webmachine requires lazy_request_body by itself, addition of DEFAULT_OPTIONS is just there for future use, Reel is undergoing some changes and it might be handy then.
