### PR TITLE
Test on the most recent Rubinius release.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ rvm:
   - 1.9.3
   - 2.0.0
   - jruby
-  - rbx-19mode
+  - rbx
 bundler_args: --without guard docs


### PR DESCRIPTION
The 'rbx-19mode' alias is no longer available on Travis.

http://rubini.us/2013/12/03/testing-with-rbx-on-travis/ :)
