### PR TITLE
Fix a possible memory leak in IOEncoder

### DIFF
--- a/lib/webmachine/streaming/io_encoder.rb
+++ b/lib/webmachine/streaming/io_encoder.rb
@@ -29,6 +29,12 @@ module Webmachine
           each {|chunk| outstream << chunk }
         end
       end
+      
+      # Adds a way for a Adapter to close the IO
+      def close
+        body.close if body.respond_to?(:close)
+      end
+      alias finish close
 
       # Returns the length of the IO stream, if known. Returns nil if
       # the stream uses an encoder or charsetter that might modify the


### PR DESCRIPTION
Afaik there was no way for a Adapter to close a Response Body when it was a IOEncoder, leaving File Descriptors unnecessary open.
