### PR TITLE
Expose Webmachine::Application to adapters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ Gemfile.lock
 **/bin
 *.rbc
 .rvmrc
+.SyncID
+.SyncIgnore

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,15 @@
 rvm:
   - 1.9.3
   - 2.0.0
+  - 2.1.0
+  - ruby-head
   - jruby
-  - rbx
+  - jruby-head
+  - rbx-2
+
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+    - rvm: jruby-head
+
 bundler_args: --without guard docs
-before_install:
-  - gem install bundler -v '= 1.5.1'

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,16 @@
 require 'rbconfig'
-
 source 'https://rubygems.org'
-
 gemspec
 
-gem 'bundler'
+group :development do
+  gem "yard"
+  gem "rake"
+end
+
+group :test do
+  gem "rspec"
+  gem "rack"
+end
 
 group :webservers do
   gem 'mongrel',  '~> 1.2.beta', :platform => [:mri, :rbx]
@@ -33,9 +39,4 @@ end
 
 platforms :jruby do
   gem 'jruby-openssl'
-end
-
-platform :rbx do
-  gem 'rubysl'
-  gem 'racc'
 end

--- a/lib/webmachine/adapter.rb
+++ b/lib/webmachine/adapter.rb
@@ -5,23 +5,17 @@ module Webmachine
   # @abstract Subclass and override {#run} to implement a custom adapter.
   class Adapter
 
-    # @return [Webmachine::Configuration] the application's configuration.
-    attr_reader :configuration
+    # @return [Webmachine::Application] returns the application
+    attr_reader :application
 
-    # @return [Webmachine::Dispatcher] the application's dispatcher.
-    attr_reader :dispatcher
-
-    # @param [Webmachine::Configuration] configuration the application's
-    # configuration.
-    # @param [Webmachine::Dispatcher] dispatcher the application's dispatcher.
-    def initialize(configuration, dispatcher)
-      @configuration = configuration
-      @dispatcher    = dispatcher
+    # @param [Webmachine::Application] application the application
+    def initialize(application)
+      @application = application
     end
 
     # Create a new adapter and run it.
-    def self.run(configuration, dispatcher)
-      new(configuration, dispatcher).run
+    def self.run(application)
+      new(application).run
     end
 
     # Start the adapter.

--- a/lib/webmachine/adapters/hatetepe.rb
+++ b/lib/webmachine/adapters/hatetepe.rb
@@ -16,8 +16,8 @@ module Webmachine
     class Hatetepe < Adapter
       def options
         {
-          :host => configuration.ip,
-          :port => configuration.port,
+          :host => application.configuration.ip,
+          :port => application.configuration.port,
           :app  => [
             ::Hatetepe::Server::Pipeline,
             ::Hatetepe::Server::KeepAlive,
@@ -40,7 +40,7 @@ module Webmachine
 
       def call(request, &respond)
         response = Webmachine::Response.new
-        dispatcher.dispatch(convert_request(request), response)
+        application.dispatcher.dispatch(convert_request(request), response)
 
         respond.call(convert_response(response))
       end

--- a/lib/webmachine/adapters/mongrel.rb
+++ b/lib/webmachine/adapters/mongrel.rb
@@ -14,13 +14,13 @@ module Webmachine
       # Starts the Mongrel adapter
       def run
         defaults = {
-          :port => configuration.port,
-          :host => configuration.ip,
-          :dispatcher => dispatcher
-        }.merge(configuration.adapter_options)
+          :port => application.configuration.port,
+          :host => application.configuration.ip,
+          :application => application
+        }.merge(application.configuration.adapter_options)
         @config = ::Mongrel::Configurator.new(defaults) do
           listener do
-            uri '/', :handler => Webmachine::Adapters::Mongrel::Handler.new(defaults[:dispatcher])
+            uri '/', :handler => Webmachine::Adapters::Mongrel::Handler.new(defaults[:application])
           end
           trap("INT") { stop }
           run
@@ -36,8 +36,8 @@ module Webmachine
 
       # A Mongrel handler for Webmachine
       class Handler < ::Mongrel::HttpHandler
-        def initialize(dispatcher)
-          @dispatcher = dispatcher
+        def initialize(application)
+          @application = application
           super()
         end
 
@@ -51,7 +51,7 @@ module Webmachine
                                             RequestBody.new(wreq))
 
           response = Webmachine::Response.new
-          @dispatcher.dispatch(request, response)
+          @application.dispatcher.dispatch(request, response)
 
           begin
             wres.status = response.code.to_i

--- a/lib/webmachine/adapters/rack.rb
+++ b/lib/webmachine/adapters/rack.rb
@@ -38,9 +38,9 @@ module Webmachine
       def run
         options = DEFAULT_OPTIONS.merge({
           :app => self,
-          :Port => configuration.port,
-          :Host => configuration.ip
-        }).merge(configuration.adapter_options)
+          :Port => application.configuration.port,
+          :Host => application.configuration.ip
+        }).merge(application.configuration.adapter_options)
 
         @server = ::Rack::Server.new(options)
         @server.start
@@ -62,7 +62,7 @@ module Webmachine
                                           RequestBody.new(rack_req))
 
         response = Webmachine::Response.new
-        @dispatcher.dispatch(request, response)
+        application.dispatcher.dispatch(request, response)
 
         response.headers['Server'] = [Webmachine::SERVER_STRING, "Rack/#{::Rack.version}"].join(" ")
 

--- a/lib/webmachine/adapters/reel.rb
+++ b/lib/webmachine/adapters/reel.rb
@@ -11,14 +11,14 @@ module Webmachine
     class Reel < Adapter
       # Used to override default Reel server options (useful in testing)
       DEFAULT_OPTIONS = {}
-      
+
       def run
         @options = DEFAULT_OPTIONS.merge({
-          :port => configuration.port,
-          :host => configuration.ip
-        }).merge(configuration.adapter_options)
+          :port => application.configuration.port,
+          :host => application.configuration.ip
+        }).merge(application.configuration.adapter_options)
 
-        if extra_verbs = configuration.adapter_options[:extra_verbs]
+        if extra_verbs = application.configuration.adapter_options[:extra_verbs]
           @extra_verbs = Set.new(extra_verbs.map(&:to_s).map(&:upcase))
         else
           @extra_verbs = Set.new
@@ -64,8 +64,9 @@ module Webmachine
 
           wm_headers  = Webmachine::Headers[request.headers.dup]
           wm_request  = Webmachine::Request.new(method, uri, wm_headers, request.body)
+
           wm_response = Webmachine::Response.new
-          @dispatcher.dispatch(wm_request, wm_response)
+          application.dispatcher.dispatch(wm_request, wm_response)
 
           fixup_headers(wm_response)
           fixup_callable_encoder(wm_response)

--- a/lib/webmachine/application.rb
+++ b/lib/webmachine/application.rb
@@ -56,7 +56,7 @@ module Webmachine
     # @return an instance of the configured web-server adapter
     # @see Adapters
     def adapter
-      @adapter ||= adapter_class.new(configuration, dispatcher)
+      @adapter ||= adapter_class.new(self)
     end
 
     # @return an instance of the configured web-server adapter

--- a/lib/webmachine/spec/adapter_lint.rb
+++ b/lib/webmachine/spec/adapter_lint.rb
@@ -5,12 +5,14 @@ shared_examples_for :adapter_lint do
   attr_accessor :client
 
   before(:all) do
-    configuration = Webmachine::Configuration.default
-    dispatcher = Webmachine::Dispatcher.new
-    dispatcher.add_route ["test"], Test::Resource
+    application = Webmachine::Application.new
+    server = TCPServer.new('0.0.0.0', 0)
+    application.configuration.port = server.addr[1]
+    server.close
+    application.dispatcher.add_route ["test"], Test::Resource
 
-    @adapter = described_class.new(configuration, dispatcher)
-    @client = Net::HTTP.new(configuration.ip, configuration.port)
+    @adapter = described_class.new(application)
+    @client = Net::HTTP.new(application.configuration.ip, application.configuration.port)
 
     Thread.abort_on_exception = true
     @server_thread = Thread.new { @adapter.run }

--- a/lib/webmachine/translation.rb
+++ b/lib/webmachine/translation.rb
@@ -1,5 +1,5 @@
 require 'i18n'
-
+I18n.enforce_available_locales = true if I18n.respond_to?(:enforce_available_locales)
 I18n.config.load_path << File.expand_path("../locale/en.yml", __FILE__)
 
 module Webmachine

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,6 @@
-$LOAD_PATH << File.expand_path("..", __FILE__)
-$LOAD_PATH << File.expand_path("../../lib", __FILE__)
-
-require 'rubygems'
-require 'webmachine'
-require 'rspec'
+require "bundler/setup"
+Bundler.require :default, :test, :webservers
 require 'logger'
-
 RSpec.configure do |config|
   config.mock_with :rspec
   config.filter_run :focus => true

--- a/spec/webmachine/adapter_spec.rb
+++ b/spec/webmachine/adapter_spec.rb
@@ -1,19 +1,18 @@
 require "spec_helper"
 
 describe Webmachine::Adapter do
-  let(:configuration) { Webmachine::Configuration.default }
-  let(:dispatcher) { Webmachine::Dispatcher.new }
+  let(:application) { Webmachine::Application.new }
   let(:adapter) do
-    described_class.new(configuration, dispatcher)
+    server = TCPServer.new('0.0.0.0', 0)
+    application.configuration.port = server.addr[1]
+    server.close
+
+    described_class.new(application)
   end
 
   describe "#initialize" do
-    it "stores the provided configuration" do
-      adapter.configuration.should eql configuration
-    end
-
-    it "stores the provided dispatcher" do
-      adapter.dispatcher.should eql dispatcher
+    it "stores the provided application" do
+      adapter.application.should eql application
     end
   end
 
@@ -22,12 +21,12 @@ describe Webmachine::Adapter do
       adapter = mock(described_class)
 
       described_class.should_receive(:new).
-        with(configuration, dispatcher).
+        with(application).
         and_return(adapter)
 
       adapter.should_receive(:run)
 
-      described_class.run(configuration, dispatcher)
+      described_class.run(application)
     end
   end
 

--- a/webmachine.gemspec
+++ b/webmachine.gemspec
@@ -18,10 +18,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency(%q<i18n>, [">= 0.4.0"])
   gem.add_runtime_dependency(%q<multi_json>)
   gem.add_runtime_dependency(%q<as-notifications>, ["~> 1.0"])
-  gem.add_development_dependency(%q<rspec>, ["~> 2.12.0"])
-  gem.add_development_dependency(%q<yard>, ["~> 0.7.3"])
-  gem.add_development_dependency(%q<rake>)
-  gem.add_development_dependency(%q<rack>)
 
   ignores = File.read(".gitignore").split(/\r?\n/).reject{ |f| f =~ /^(#.+|\s*)$/ }.map {|f| Dir[f] }.flatten
   gem.files = (Dir['**/*','.gitignore'] - ignores).reject {|f| !File.file?(f) }


### PR DESCRIPTION
In order to implement secure Proxy support i need to get a hold of the application instance in every adapter, this adds that.

It also changes specs so each adapter gets its own random Port which fixes some #126 issues.
