### PR TITLE
Update Reel adapter for Reel 0.5

### DIFF
--- a/lib/webmachine/adapters/reel.rb
+++ b/lib/webmachine/adapters/reel.rb
@@ -24,7 +24,7 @@ module Webmachine
           @extra_verbs = Set.new
         end
 
-        @server = ::Reel::Server.supervise(@options[:host], @options[:port], &method(:process))
+        @server = ::Reel::Server::HTTP.supervise(@options[:host], @options[:port], &method(:process))
 
         # FIXME: this will no longer work on Ruby 2.0. We need Celluloid.trap
         trap("INT") { @server.terminate; exit 0 }


### PR DESCRIPTION
This takes the arguments in the form they are passed in here. `Reel::Server` does not.
