### PR TITLE
Clarify changes made to Rack::RequestBody

### DIFF
--- a/lib/webmachine/adapters/rack.rb
+++ b/lib/webmachine/adapters/rack.rb
@@ -125,10 +125,13 @@ module Webmachine
           @request = request
         end
 
-        # Tries to convert the body to a IO object.
-        # @return [IO] the request body as a IO object, or nil.
+        # Rack Servers differ in the way you can access their request bodys.
+        # While some allow you to directly get a Ruby IO object others don't.
+        # You have to check the methods they expose, like #gets, #read, #each, #rewind and maybe others.
+        # See: https://github.com/rack/rack/blob/rack-1.5/lib/rack/lint.rb#L296
+        # @return [IO] the request body
         def to_io
-          IO.try_convert(@request.body)
+          @request.body
         end
 
         # Converts the body to a String so you can work with the entire


### PR DESCRIPTION
While the Rack Spec doesn't need Servers to have a #to_io method for request bodies at the moment, Puma for instance does it currently: https://github.com/puma/puma/blob/v2.8.2/lib/puma/client.rb#L27.
Yahns, Unicorn and Rainbows don't even use standard ruby sockets but http://bogomips.org/kgio/ which are compatible but don't have a #to_io method for their request bodies.

To use this in a Webmachine::Resource

``` ruby
class UploadResource < Webmachine::Resource
  def allowed_methods; %W[POST]; end

  def content_types_accepted
    [['multipart/form-data', :from_form]]
  end

  def process_post
    @request.body.to_io.each do |body|
      puts body
    end
    true
  end

  def from_form; end
end
```

This has the advantage that you don't cache the whole body in memory like the current rack adapter does it with
@request.body.each.

Please be aware: only the rack adapter has this #to_io method currently guaranteed for request bodies, others don't have it necessarily.
