### PR TITLE
Deprecate the string version of the route splat.

### DIFF
--- a/lib/webmachine/dispatcher/route.rb
+++ b/lib/webmachine/dispatcher/route.rb
@@ -22,7 +22,10 @@ module Webmachine
 
       # When used in a path specification, will match all remaining
       # segments
-      MATCH_ALL = '*'.freeze
+      MATCH_ALL = :*
+
+      # String version of MATCH_ALL, deprecated. Use the symbol instead.
+      MATCH_ALL_STR = '*'.freeze
 
       # Creates a new Route that will associate a pattern to a
       # {Resource}.
@@ -64,6 +67,8 @@ module Webmachine
         resource = args.pop
         guards = args
         guards << Proc.new if block_given?
+
+        warn t('match_all_symbol') if path_spec.include? MATCH_ALL_STR
 
         @path_spec = path_spec
         @guards    = guards
@@ -107,6 +112,8 @@ module Webmachine
           case
           when spec.empty? && tokens.empty?
             return depth
+          when spec == [MATCH_ALL_STR]
+            return [depth, tokens]
           when spec == [MATCH_ALL]
             return [depth, tokens]
           when tokens.empty?

--- a/lib/webmachine/locale/en.yml
+++ b/lib/webmachine/locale/en.yml
@@ -27,3 +27,4 @@ en:
     invalid_media_type: "Invalid media type: %{type}"
     not_resource_class: "%{class} is not a subclass of Webmachine::Resource"
     process_post_invalid: "process_post returned %{result}"
+    match_all_symbol: '"*" as a path segment is deprecated and will be removed in a future release. Please use :*'


### PR DESCRIPTION
We've talked about doing this for a long time because `'*'` is a valid URI path
segment. Replacing it with `:*` makes the difference more explicit.
