### PR TITLE
Fix error when Accept header is specified more than once

### DIFF
--- a/lib/webmachine/decision/conneg.rb
+++ b/lib/webmachine/decision/conneg.rb
@@ -13,7 +13,8 @@ module Webmachine
       # appropriate media type.
       # @api private
       def choose_media_type(provided, header)
-        requested = MediaTypeList.build(header.split(/\s*,\s*/))
+        types = Array(header).map{|h| h.split(/\s*,\s*/) }.flatten
+        requested = MediaTypeList.build(types)
         provided = provided.map do |p| # normalize_provided
           MediaType.parse(p)
         end

--- a/spec/webmachine/decision/conneg_spec.rb
+++ b/spec/webmachine/decision/conneg_spec.rb
@@ -47,6 +47,12 @@ describe Webmachine::Decision::Conneg do
                                   "bah;")
       }.to raise_error(Webmachine::MalformedRequest)
     end
+    
+    it "should choose a type when more than one accept header is present" do
+      expect(subject.choose_media_type(["text/html"],
+                                ["text/html", "text/plain"])).to eq("text/html")
+
+    end
   end
 
   context "choosing an encoding" do


### PR DESCRIPTION
Currently, when more than one Accept header field is present in the request, it's causing a 500 Internal Server Error to be returned.

Real world example:
Googlebot (as tested from "Fetch as Google" in Webmaster Tools) is setting the Accept request header twice, and this error is causing Google to think my site is unavailable.

http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2 allows for header fields to be set more than once (read the entire last paragraph under "4.2 Message Headers"), so this is a case that should be handled without error.
