### PR TITLE
Using URL.decode rather than CGI.unescape to correctly decode URL components.

### DIFF
--- a/lib/webmachine/dispatcher/route.rb
+++ b/lib/webmachine/dispatcher/route.rb
@@ -119,7 +119,7 @@ module Webmachine
           when tokens.empty?
             return false
           when Symbol === spec.first
-            bindings[spec.first] = CGI.unescape(tokens.first)
+            bindings[spec.first] = URI.decode(tokens.first)
           when spec.first == tokens.first
           else
             return false

--- a/spec/webmachine/dispatcher/route_spec.rb
+++ b/spec/webmachine/dispatcher/route_spec.rb
@@ -17,12 +17,12 @@ describe Webmachine::Dispatcher::Route do
 
     describe 'a path_info fragment' do
       before do
-        uri.path = '/hello/planet%20earth'
+        uri.path = '/hello/planet%20earth%20++'
       end
 
       it 'should decode the value' do
         route.apply(request)
-        expect(request.path_info).to eq({:string => 'planet earth'})
+        expect(request.path_info).to eq({:string => 'planet earth ++'})
       end
     end
   end


### PR DESCRIPTION
See comments on https://github.com/seancribbs/webmachine-ruby/commit/f063e3b95abcbff3d3482403b325141531a5fc39
