### PR TITLE
Updated to support file extensions to prepend accept header

### DIFF
--- a/lib/webmachine/dispatcher/route.rb
+++ b/lib/webmachine/dispatcher/route.rb
@@ -122,6 +122,7 @@ module Webmachine
           when Symbol === spec.first
             bindings[spec.first] = URI.decode(tokens.first)
           when spec.first == tokens.first
+          when tokens.length == 1 && spec.first == tokens.first.split('.').first 
           else
             return false
           end

--- a/lib/webmachine/resource.rb
+++ b/lib/webmachine/resource.rb
@@ -1,3 +1,4 @@
+require 'mimemagic'
 require 'webmachine/resource/callbacks'
 require 'webmachine/resource/encodings'
 require 'webmachine/resource/entity_tags'
@@ -36,6 +37,12 @@ module Webmachine
     # @param [Response] response the response object
     # @return [Resource] the new resource
     def self.new(request, response)
+      ext = request.uri.path.split('/').last.split('.').last
+      if ext
+        type = MimeMagic.by_extension(ext)
+        accept = request.headers['accept']
+        request.headers['accept'] = [type, accept].reject(&:nil?).join ',' 
+      end
       instance = allocate
       instance.instance_variable_set(:@request, request)
       instance.instance_variable_set(:@response, response)

--- a/webmachine.gemspec
+++ b/webmachine.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency(%q<i18n>, [">= 0.4.0"])
   gem.add_runtime_dependency(%q<multi_json>)
   gem.add_runtime_dependency(%q<as-notifications>, ["~> 1.0"])
+  gem.add_runtime_dependency(%q<mimemagic>, ["~> 0.3"])
 
   ignores = File.read(".gitignore").split(/\r?\n/).reject{ |f| f =~ /^(#.+|\s*)$/ }.map {|f| Dir[f] }.flatten
   gem.files = (Dir['**/*','.gitignore'] - ignores).reject {|f| !File.file?(f) }


### PR DESCRIPTION
I ran into an issue where I wanted to be able to pass file extensions to routes and have them transparently be handled by the correct resource. I noticed the following issue, but wasn't really happy with the solution (I'm trying to avoid middleware, and needed to ensure my resource would match the request): https://github.com/webmachine/webmachine-ruby/issues/194

It seemed like the cleanest solution was to include it directly into webmachine (since the simplest solution was the update the route parsing). This patch inspects the file extension (anything after the last  period of the last URI element), and looks up the mime type for it. It then prepends that mime type to the existing accept headers. It should behave the same as it always has in the absence of a file extension, and should still route to the first matching type. 

The only potentially unexpected behavior I've seen (which is probably worth debating) is that, if you send an extension that maps to a non-supported type, it will try to use the first supported type (so, say you don't support .json, but you do support html. If you use your browser to hit the endpoint, the html callback will be used because the browser will send an Accept header with text/html).

Thoughts? I'm certainly open to suggestions on this.