### PR TITLE
Added support for regex in path spec. 

### DIFF
--- a/lib/webmachine/dispatcher/route.rb
+++ b/lib/webmachine/dispatcher/route.rb
@@ -119,6 +119,13 @@ module Webmachine
             return [depth, tokens]
           when tokens.empty?
             return false
+          when Regexp === spec.first
+            matches = spec.first.match URI.decode(tokens.first)
+            if matches
+              bindings[:captures] = (bindings[:captures] || []) + matches.captures
+            else
+              return false
+            end
           when Symbol === spec.first
             bindings[spec.first] = URI.decode(tokens.first)
           when spec.first == tokens.first

--- a/spec/webmachine/dispatcher/route_spec.rb
+++ b/spec/webmachine/dispatcher/route_spec.rb
@@ -180,7 +180,6 @@ describe Webmachine::Dispatcher::Route do
         end
       end
     end
-
     context "on a deep path" do
       subject { described_class.new(%w{foo bar baz}, resource) }
       let(:uri) { URI.parse("http://localhost:8080/foo/bar/baz") }
@@ -203,6 +202,21 @@ describe Webmachine::Dispatcher::Route do
 
         it "should assign the path variables in the bindings" do
           expect(request.path_info).to eq({:id => "bar"})
+        end
+      end
+      context "with regex" do
+        subject { described_class.new([/foo/, /(.*)/, 'baz'], resource) }
+
+        it "should assign the captures path variables" do
+          expect(request.path_info).to eq({:captures => ["bar"]})
+        end
+      end
+      context "with multi-capture regex" do
+        subject { described_class.new([/foo/, /(.*)/, /baz\.(.*)/], resource) }
+        let(:uri) { URI.parse("http://localhost:8080/foo/bar/baz.json") }
+
+        it "should assign the captures path variables" do
+          expect(request.path_info).to eq({:captures => ["bar", "json"]})
         end
       end
 


### PR DESCRIPTION
Supports adding :captures path_info element for any capture groups.

I ran the following quick benchmark to verify that traditional (string/symbol) routes are not impacted significantly. Basically, we check whether the spec is a regex (like how Symbols work), and only then incur the overhead of regex matching and pulling out capture groups.

```ruby
require 'webmachine'
require 'benchmark'

request = Webmachine::Request.new("GET", URI.parse("http://localhost:8080/hello/bob.json"), Webmachine::Headers["accept" => "*/*"], "")
route1 =  Webmachine::Dispatcher::Route.new ['hello', :string], Class.new(Webmachine::Resource), {}
route2 =  Webmachine::Dispatcher::Route.new ['hello', /(.*)/], Class.new(Webmachine::Resource), {}

n = 50000
Benchmark.bm do |x|
  x.report('Traditional') {n.times {route1.match? request}}
  x.report('Regex') {n.times {route2.match? request}}
end
```