### PR TITLE
Added support for named captures

### DIFF
--- a/documentation/routes.md
+++ b/documentation/routes.md
@@ -20,6 +20,21 @@ App = Webmachine::Application.new do |app|
     # but will not provide any path_info
     add ["orders", :*], OrderResource
 
+    # Will map to any path that matches the given components and regular expression
+    # Any capture groups specified in the regex will be made available in
+    # request.path_info[:captures. In this case, you would get one or two
+    # values in :captures depending on whether your request looked like:
+    # /orders/1/cancel
+    # or
+    # /orders/1/cancel.json
+    add ["orders", :id, /([^.]*)\.?(.*)?/], OrderResource
+
+    # You can even use named captures with regular expressions. This will 
+    # automatically put the captures into path_info. In the below example,
+    # you would get :id from the symbol, along with :action and :format
+    # from the regex. :format in this case would be optional.
+    add ["orders", :id, /(?<action>)[^.]*)\.?(?<format>.*)?/], OrderResource
+
     # will map to any path
     add [:*], DefaultResource
   end

--- a/lib/webmachine/dispatcher/route.rb
+++ b/lib/webmachine/dispatcher/route.rb
@@ -122,7 +122,14 @@ module Webmachine
           when Regexp === spec.first
             matches = spec.first.match URI.decode(tokens.first)
             if matches
-              bindings[:captures] = (bindings[:captures] || []) + matches.captures
+              if spec.first.named_captures.empty?
+                bindings[:captures] = (bindings[:captures] || []) + matches.captures
+              else
+                spec.first.named_captures.reduce(bindings) do |bindings, (name, idxs)|
+                  bindings[name.to_sym] = matches.captures[idxs.first-1]
+                  bindings
+                end
+              end
             else
               return false
             end

--- a/spec/webmachine/dispatcher/route_spec.rb
+++ b/spec/webmachine/dispatcher/route_spec.rb
@@ -219,6 +219,14 @@ describe Webmachine::Dispatcher::Route do
           expect(request.path_info).to eq({:captures => ["bar", "json"]})
         end
       end
+      context "with named capture regex" do
+        subject { described_class.new(['foo', :bar, /(?<baz>[^.]+)\.(?<format>.*)/], resource) }
+        let(:uri) { URI.parse("http://localhost:8080/foo/bar/baz.json") }
+
+        it "should assign the captures path variables" do
+          expect(request.path_info).to eq({bar: 'bar', baz: 'baz', format: "json"})
+        end
+      end
 
       context "with a splat" do
         subject { described_class.new(['foo', :*], resource) }


### PR DESCRIPTION
This extends regex support to explicitly add in named captures. Specifically, if there are any named captures, they will be automatically added to the request.path_info with the specified name (making it easier to reference specific capture groups from the regex).

Technically, named captures support multiple captures with the same name. In order to be consistent with how symbols work right now, we only expose one (so, if you were to use the same named capture multiple times, only one of them would be available in path_info).