### PR TITLE
Fixing multiple cookie handling

### DIFF
--- a/lib/webmachine/response.rb
+++ b/lib/webmachine/response.rb
@@ -50,7 +50,7 @@ module Webmachine
       when nil
         headers['Set-Cookie'] = [cookie]
       when Array
-        headers['Set-Cookie'] = headers['Set-Cookie'] << cookie
+        headers['Set-Cookie'] << cookie
       end
     end
 

--- a/lib/webmachine/response.rb
+++ b/lib/webmachine/response.rb
@@ -52,7 +52,7 @@ module Webmachine
       when String
         headers['Set-Cookie'] = [headers['Set-Cookie'], cookie]
       when Array
-        headers['Set-Cookie'] = headers['Set-Cookie'] + cookie
+        headers['Set-Cookie'] = headers['Set-Cookie'] << cookie
       end
     end
 

--- a/lib/webmachine/response.rb
+++ b/lib/webmachine/response.rb
@@ -48,9 +48,7 @@ module Webmachine
       cookie = Webmachine::Cookie.new(name, value, attributes).to_s
       case headers['Set-Cookie']
       when nil
-        headers['Set-Cookie'] = cookie
-      when String
-        headers['Set-Cookie'] = [headers['Set-Cookie'], cookie]
+        headers['Set-Cookie'] = [cookie]
       when Array
         headers['Set-Cookie'] = headers['Set-Cookie'] << cookie
       end

--- a/spec/webmachine/response_spec.rb
+++ b/spec/webmachine/response_spec.rb
@@ -31,7 +31,6 @@ describe Webmachine::Response do
     end
 
     describe "setting multiple cookies" do
-      puts "Multiple cookie test"
       let(:cookie2) { "rodeo" }
       let(:cookie2_value) { "clown" }
       let(:cookie3) {"color"}
@@ -42,7 +41,6 @@ describe Webmachine::Response do
       end
 
       it "should have a proper Set-Cookie header" do
-        puts subject.headers["Set-Cookie"]
         expect(subject.headers["Set-Cookie"]).to be_a Array
         expect(subject.headers["Set-Cookie"]).to include "rodeo=clown"
         expect(subject.headers["Set-Cookie"]).to include "monster=mash"

--- a/spec/webmachine/response_spec.rb
+++ b/spec/webmachine/response_spec.rb
@@ -31,14 +31,22 @@ describe Webmachine::Response do
     end
 
     describe "setting multiple cookies" do
+      puts "Multiple cookie test"
       let(:cookie2) { "rodeo" }
       let(:cookie2_value) { "clown" }
-      before(:each) { subject.set_cookie(cookie2, cookie2_value) }
+      let(:cookie3) {"color"}
+      let(:cookie3_value) {"blue"}
+      before(:each) do 
+        subject.set_cookie(cookie2, cookie2_value)
+        subject.set_cookie(cookie3, cookie3_value)
+      end
 
       it "should have a proper Set-Cookie header" do
+        puts subject.headers["Set-Cookie"]
         expect(subject.headers["Set-Cookie"]).to be_a Array
         expect(subject.headers["Set-Cookie"]).to include "rodeo=clown"
         expect(subject.headers["Set-Cookie"]).to include "monster=mash"
+        expect(subject.headers["Set-Cookie"]).to include "color=blue"
       end
     end
   end


### PR DESCRIPTION
Previously, set_cookie would set the cookies to a string, and if more were added, it was turned into an array. After turning into an array, adding more cookies failed.

To simplify the process, the first cookie is added as an array. Added test to ensure that adding more than one cookie works, although it should be unnecessary now that there aren't three cases.