### PR TITLE
fix: use Integer instead of Fixnum

### DIFF
--- a/lib/webmachine/configuration.rb
+++ b/lib/webmachine/configuration.rb
@@ -5,7 +5,7 @@ module Webmachine
   # defaults will be filled in when {Webmachine::run} is called.
   # @attr [String] ip the interface to bind to, defaults to "0.0.0.0"
   #    (all interfaces)
-  # @attr [Fixnum] port the port to bind to, defaults to 8080
+  # @attr [Integer] port the port to bind to, defaults to 8080
   # @attr [Symbol] adapter the adapter to use, defaults to :WEBrick
   # @attr [Hash] adapter_options adapter-specific options, defaults to {}
   Configuration = Struct.new(:ip, :port, :adapter, :adapter_options)

--- a/lib/webmachine/decision/flow.rb
+++ b/lib/webmachine/decision/flow.rb
@@ -35,7 +35,7 @@ module Webmachine
       # Handles standard decisions where halting is allowed
       def decision_test(test, iftrue, iffalse)
         case test
-        when Fixnum # Allows callbacks to "halt" with a given response code
+        when Integer # Allows callbacks to "halt" with a given response code
           test
         when Falsey
           iffalse
@@ -77,7 +77,7 @@ module Webmachine
       # Content-MD5 valid?
       def b9a
         case valid = resource.validate_content_checksum
-        when Fixnum
+        when Integer
           valid
         when true
           :b9b
@@ -105,7 +105,7 @@ module Webmachine
         case result
         when true
           :b7
-        when Fixnum
+        when Integer
           result
         when String
           response.headers['WWW-Authenticate'] = result
@@ -280,7 +280,7 @@ module Webmachine
         when String, URI
           response.headers[LOCATION] = uri.to_s
           301
-        when Fixnum
+        when Integer
           uri
         else
           :p3
@@ -313,7 +313,7 @@ module Webmachine
         when String, URI
           response.headers[LOCATION] = uri.to_s
           301
-        when Fixnum
+        when Integer
           uri
         else
           :l5
@@ -342,7 +342,7 @@ module Webmachine
         when String, URI
           response.headers[LOCATION] = uri.to_s
           307
-        when Fixnum
+        when Integer
           uri
         else
           :m5
@@ -422,13 +422,13 @@ module Webmachine
             request.disp_path = new_uri.path
             response.headers[LOCATION] = new_uri.to_s
             result = accept_helper
-            return result if Fixnum === result
+            return result if Integer === result
           end
         else
           case result = resource.process_post
           when true
             encode_body_if_set
-          when Fixnum
+          when Integer
             return result
           else
             raise InvalidResource, t('process_post_invalid', :result => result.inspect)
@@ -456,7 +456,7 @@ module Webmachine
           409
         else
           res = accept_helper
-          (Fixnum === res) ? res : :p11
+          (Integer === res) ? res : :p11
         end
       end
 
@@ -473,7 +473,7 @@ module Webmachine
           content_type = metadata[CONTENT_TYPE]
           handler = resource.content_types_provided.find {|ct, _| content_type.type_matches?(MediaType.parse(ct)) }.last
           result = resource.send(handler)
-          if Fixnum === result
+          if Integer === result
             result
           else
             response.body = result
@@ -501,7 +501,7 @@ module Webmachine
           409
         else
           res = accept_helper
-          (Fixnum === res) ? res : :p11
+          (Integer === res) ? res : :p11
         end
       end
 

--- a/lib/webmachine/decision/fsm.rb
+++ b/lib/webmachine/decision/fsm.rb
@@ -29,7 +29,7 @@ module Webmachine
           trace_decision(state)
           result = handle_exceptions { send(state) }
           case result
-          when Fixnum # Response code
+          when Integer # Response code
             respond(result)
             break
           when Symbol # Next state

--- a/lib/webmachine/decision/helpers.rb
+++ b/lib/webmachine/decision/helpers.rb
@@ -95,7 +95,7 @@ module Webmachine
       # is a String or IO with known size.
       def body_is_fixed_length?
         response.body.respond_to?(:bytesize) &&
-          Fixnum === response.body.bytesize
+          Integer === response.body.bytesize
       end
     end # module Helpers
   end # module Decision

--- a/lib/webmachine/dispatcher/route.rb
+++ b/lib/webmachine/dispatcher/route.rb
@@ -103,7 +103,7 @@ module Webmachine
       # accumulating variable bindings.
       # @param [Array<String>] tokens the list of path segments
       # @param [Hash] bindings where path bindings will be stored
-      # @return [Fixnum, Array<Fixnum, Array>, false] either the depth
+      # @return [Integer, Array<Integer, Array>, false] either the depth
       #   that the path matched at, the depth and tokens matched by
       #   {MATCH_ALL}, or false if it didn't match.
       def bind(tokens, bindings)

--- a/lib/webmachine/errors.rb
+++ b/lib/webmachine/errors.rb
@@ -9,7 +9,7 @@ module Webmachine
 
   # Renders a standard error message body for the response. The
   # standard messages are defined in localization files.
-  # @param [Fixnum] code the response status code
+  # @param [Integer] code the response status code
   # @param [Request] req the request object
   # @param [Response] req the response object
   # @param [Hash] options keys to override the defaults when rendering

--- a/lib/webmachine/resource/callbacks.rb
+++ b/lib/webmachine/resource/callbacks.rb
@@ -103,7 +103,7 @@ module Webmachine
       # If the entity length on PUT or POST is invalid, this should
       # return false, which will result in a '413 Request Entity Too
       # Large' response. Defaults to true.
-      # @param [Fixnum] length the size of the request body (entity)
+      # @param [Integer] length the size of the request body (entity)
       # @return [true,false] Whether the body is a valid length (not too
       #    large)
       # @api callback
@@ -192,7 +192,7 @@ module Webmachine
 
       # If post_is_create? returns false, then this will be called to
       # process any POST request. If it succeeds, it should return true.
-      # @return [true,false,Fixnum] Whether the POST was successfully
+      # @return [true,false,Integer] Whether the POST was successfully
       #    processed, or an alternate response code
       # @api callback
       def process_post

--- a/lib/webmachine/response.rb
+++ b/lib/webmachine/response.rb
@@ -4,7 +4,7 @@ module Webmachine
     # @return [HeaderHash] Response headers that will be sent to the client
     attr_reader :headers
 
-    # @return [Fixnum] The HTTP status code of the response
+    # @return [Integer] The HTTP status code of the response
     attr_accessor :code
 
     # @return [String, #each] The response body

--- a/lib/webmachine/streaming/io_encoder.rb
+++ b/lib/webmachine/streaming/io_encoder.rb
@@ -39,7 +39,7 @@ module Webmachine
       # Returns the length of the IO stream, if known. Returns nil if
       # the stream uses an encoder or charsetter that might modify the
       # length of the stream, or the stream size is unknown.
-      # @return [Fixnum] the size, in bytes, of the underlying IO, or
+      # @return [Integer] the size, in bytes, of the underlying IO, or
       #   nil if unsupported
       def size
         if is_unencoded?


### PR DESCRIPTION
This removes 'Warning: constant ::Fixnum is deprecated' in ruby >= 2.4.0