### PR TITLE
Extend exception handling support.

### DIFF
--- a/lib/webmachine/decision/fsm.rb
+++ b/lib/webmachine/decision/fsm.rb
@@ -2,6 +2,7 @@
 require 'webmachine/trace'
 require 'webmachine/translation'
 require 'webmachine/constants'
+require 'webmachine/rescueable_exception'
 
 module Webmachine
   module Decision
@@ -48,12 +49,12 @@ module Webmachine
 
       def handle_exceptions
         yield
+      rescue Webmachine::RescueableException => e
+        resource.handle_exception(e)
+        500
       rescue MalformedRequest => e
         Webmachine.render_error(400, request, response, :message => e.message)
         400
-      rescue => e
-        resource.handle_exception(e)
-        500
       end
 
       def respond(code, headers={})

--- a/lib/webmachine/rescueable_exception.rb
+++ b/lib/webmachine/rescueable_exception.rb
@@ -1,0 +1,62 @@
+module Webmachine::RescueableException
+  require_relative 'errors'
+  require 'set'
+
+  UNRESCUEABLE_DEFAULTS =  [
+    Webmachine::MalformedRequest,
+    NoMemoryError, SystemExit, SignalException
+  ].freeze
+
+  UNRESCUEABLE = Set.new UNRESCUEABLE_DEFAULTS.dup
+  private_constant :UNRESCUEABLE
+
+  def self.===(e)
+    case e
+    when *UNRESCUEABLE then false
+    else true
+    end
+  end
+
+  #
+  # Remove modifications to Webmachine::RescueableException.
+  # Restores default list of unrescue-able exceptions,
+  #
+  # @return [nil]
+  #
+  def self.default!
+    UNRESCUEABLE.replace Set.new(UNRESCUEABLE_DEFAULTS.dup)
+    nil
+  end
+
+  #
+  # @return [Array<Exception>]
+  #   Returns an Array of exceptions that will not be
+  #   rescued by {Webmachine::Resource#handle_exception}.
+  #
+  def self.unrescueables
+    UNRESCUEABLE.to_a
+  end
+
+  #
+  # Add a variable number of exceptions that should be rescued by
+  # {Webmachine::Resource#handle_exception}. See {UNRESCUEABLE_DEFAULTS}
+  # for a list of exceptions that are not caught by default.
+  #
+  # @param (see #remove)
+  #
+  def self.add(*exceptions)
+    exceptions.each{|e| UNRESCUEABLE.delete(e)}
+  end
+
+  #
+  # Remove a variable number ofexceptions from being rescued by
+  # {Webmachine::Resource#handle_exception}. See {UNRESCUEABLE_DEFAULTS}
+  # for a list of exceptions that are not caught by default.
+  #
+  # @param [Exception] *exceptions
+  #   A subclass of Exception.
+  #
+  def self.remove(*exceptions)
+    exceptions.each{|e| UNRESCUEABLE.add(e)}
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,14 @@ RSpec.configure do |config|
     config.order = :random
   end
 
+  config.before :each do
+    Webmachine::RescueableException.remove(RSpec::Mocks::MockExpectationError)
+  end
+
+  config.after :each do
+    Webmachine::RescueableException.default!
+  end
+
   config.before(:suite) do
     options = {
       :Logger => NullLogger.new(STDERR),

--- a/spec/webmachine/rescueable_exception_spec.rb
+++ b/spec/webmachine/rescueable_exception_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+RSpec.describe Webmachine::RescueableException do
+  before { described_class.default! }
+
+  describe ".unrescueables" do
+    specify "returns an array of unrescueable exceptions" do
+      expect(described_class.unrescueables).to eq(described_class::UNRESCUEABLE_DEFAULTS)
+    end
+
+    specify "returns an array of unrescueable exceptions, with custom exceptions added" do
+      described_class.remove(Exception)
+      expect(described_class.unrescueables).to eq(described_class::UNRESCUEABLE_DEFAULTS.dup.concat([Exception]))
+    end
+  end
+end


### PR DESCRIPTION
After this commit, the following scenarios are covered in addition to the
existing rescueable exceptions:

```ruby
class Resource < Webmachine::Resource
  def resource_exists?
    require 'delayed-failed-require-oh-no'
  end

  def handle_exception(e)
    Airbrake.notify(e)
  end
end
```

```ruby
class Resource < Webmachine::Resource
  ThirdPartyLibException = Class.new(Exception)

  def resource_exists?
    raise ThirdPartyLibException, "error by some third party lib we don't control"
  end

  def handle_exception(e)
    Airbrake.notify(e)
  end
end
```

The following exceptions are not rescue-able, by default:
Webmachine::MalformedRequest, SystemExit, SignalException, & NoMemoryError.

But this is now configurable:
```ruby
class Resource < Webmachine::Resource
  Webmachine::RescueableException.add(Webmachine::MalformedRequest)

  def handle_exception(e)
    # Now we can add custom handlers for Webmachine::MalformedRequest.
    # Formerly not possible to customise how this exception is handled.
  end
end
```