### PR TITLE
Fix failing expectation on finish_request

### DIFF
--- a/spec/webmachine/decision/fsm_spec.rb
+++ b/spec/webmachine/decision/fsm_spec.rb
@@ -97,7 +97,7 @@ describe Webmachine::Decision::FSM do
 
     it 'does not call resource.handle_exception' do
       Webmachine::RescuableException.remove(exception)
-      allow(resource).to receive(:finish_request) { raise exception }
+      expect(resource).to receive(:finish_request) { raise exception }
       expect(resource).to_not receive(:handle_exception)
       run_with_exception
     end

--- a/spec/webmachine/decision/fsm_spec.rb
+++ b/spec/webmachine/decision/fsm_spec.rb
@@ -95,17 +95,16 @@ describe Webmachine::Decision::FSM do
   describe 'handling of exceptions from resource.finish_request' do
     let(:exception) { Class.new(Exception).new }
 
-    before do
+    it 'does not call resource.handle_exception' do
       Webmachine::RescuableException.remove(exception)
       allow(resource).to receive(:finish_request) { raise exception }
-    end
-
-    it 'does not call resource.handle_exception' do
       expect(resource).to_not receive(:handle_exception)
       run_with_exception
     end
 
     it 'does not call resource.finish_request again' do
+      Webmachine::RescuableException.remove(exception)
+      allow(resource).to receive(:finish_request) { raise exception }
       expect(resource).to_not receive(:finish_request) { raise }
       run_with_exception
     end

--- a/spec/webmachine/decision/fsm_spec.rb
+++ b/spec/webmachine/decision/fsm_spec.rb
@@ -104,8 +104,7 @@ describe Webmachine::Decision::FSM do
 
     it 'does not call resource.finish_request again' do
       Webmachine::RescuableException.remove(exception)
-      allow(resource).to receive(:finish_request) { raise exception }
-      expect(resource).to_not receive(:finish_request) { raise }
+      expect(resource).to receive(:finish_request).once { raise exception }
       run_with_exception
     end
   end

--- a/spec/webmachine/decision/fsm_spec.rb
+++ b/spec/webmachine/decision/fsm_spec.rb
@@ -106,7 +106,7 @@ describe Webmachine::Decision::FSM do
     end
 
     it 'does not call resource.finish_request again' do
-      expect(resource).to_not receive(:finish_request).once { raise }
+      expect(resource).to_not receive(:finish_request) { raise }
       run_with_exception
     end
   end


### PR DESCRIPTION
I've noticed that specs are failing when run on `'rspec',  '= 3.8.0'` (see https://travis-ci.org/webmachine/webmachine-ruby/jobs/465823764).

The problem is within `to_not receive(...).once`, which is not a valid way to express an expectation. 

On previous releases of rspec it can be attributed quite the opposite behaviour. It would be turned into an expectation of being called exactly once. That would also explain a passing spec before.

Related issues from `rspec-mocks` are https://github.com/rspec/rspec-mocks/issues/1210 and https://github.com/rspec/rspec-mocks/pull/1212 and [changelog](https://github.com/rspec/rspec-mocks/blob/master/Changelog.md#380--2018-08-04).