### PR TITLE
feat: make rack env available on the webmachine request when using rack adapter

### DIFF
--- a/lib/webmachine/adapters/rack.rb
+++ b/lib/webmachine/adapters/rack.rb
@@ -106,13 +106,23 @@ module Webmachine
 
       private
       def build_webmachine_request(rack_req, headers)
-        Webmachine::Request.new(rack_req.request_method,
+        RackRequest.new(rack_req.request_method,
                                 rack_req.url,
                                 headers,
                                 RequestBody.new(rack_req),
                                 routing_tokens(rack_req),
-                                base_uri(rack_req)
+                                base_uri(rack_req),
+                                rack_req.env
                                )
+      end
+
+      class RackRequest < Webmachine::Request
+        attr_reader :env
+
+        def initialize(method, uri, headers, body, routing_tokens, base_uri, env)
+          super(method, uri, headers, body, routing_tokens, base_uri)
+          @env = env
+        end
       end
 
       class RackResponse

--- a/lib/webmachine/spec/test_resource.rb
+++ b/lib/webmachine/spec/test_resource.rb
@@ -19,7 +19,8 @@ module Test
         ["test/response.fiberbody", :to_fiber],
         ["test/response.iobody", :to_io_body],
         ["test/response.cookies", :to_cookies],
-        ["test/response.request_uri", :to_request_uri]
+        ["test/response.request_uri", :to_request_uri],
+        ["test/response.rack_env", :to_rack_env]
       ]
     end
 
@@ -74,6 +75,10 @@ module Test
 
     def to_request_uri
       request.uri.to_s
+    end
+
+    def to_rack_env
+      request.env.to_json
     end
   end
 end

--- a/spec/webmachine/adapters/rack_spec.rb
+++ b/spec/webmachine/adapters/rack_spec.rb
@@ -53,5 +53,10 @@ describe Webmachine::Adapters::Rack do
       rack_response = get "test", nil, {"HTTP_ACCEPT" => "test/response.request_uri"}
       expect(rack_response.body).to eq "http://example.org/test"
     end
+
+    it "provides the rack env on the request" do
+      rack_response = get "test", nil, {"HTTP_ACCEPT" => "test/response.rack_env"}
+      expect(JSON.parse(rack_response.body).keys).to include "rack.input"
+    end
   end
 end


### PR DESCRIPTION
In the manner of Sinatra, make the rack env available on the request object when either of the Rack adapters are used.

I monkey patched this into my own project, and it was so useful I thought I'd contribute it back.