### PR TITLE
Rename SPLIT_SEMI constant to SPLIT_COMMA

### DIFF
--- a/lib/webmachine/constants.rb
+++ b/lib/webmachine/constants.rb
@@ -59,8 +59,8 @@
   # Charset string
   CHARSET = 'Charset'.freeze
 
-  # Semicolon split match
-  SPLIT_SEMI = /\s*,\s*/.freeze
+  # Comma split match
+  SPLIT_COMMA = /\s*,\s*/.freeze
 
   # Star Character
   STAR = '*'.freeze

--- a/lib/webmachine/decision/conneg.rb
+++ b/lib/webmachine/decision/conneg.rb
@@ -14,7 +14,7 @@ module Webmachine
       # appropriate media type.
       # @api private
       def choose_media_type(provided, header)
-        types = Array(header).map{|h| h.split(SPLIT_SEMI) }.flatten
+        types = Array(header).map{|h| h.split(SPLIT_COMMA) }.flatten
         requested = MediaTypeList.build(types)
         provided = provided.map do |p| # normalize_provided
           MediaType.parse(p)
@@ -57,7 +57,7 @@ module Webmachine
       # @api private
       def choose_language(provided, header)
         if provided && !provided.empty?
-          requested = PriorityList.build(header.split(SPLIT_SEMI))
+          requested = PriorityList.build(header.split(SPLIT_COMMA))
           star_priority = requested.priority_of(STAR)
           any_ok = star_priority && star_priority > 0.0
           accepted = requested.find do |priority, range|
@@ -99,7 +99,7 @@ module Webmachine
       # @api private
       def do_choose(choices, header, default)
         choices = choices.dup.map {|s| s.downcase }
-        accepted = PriorityList.build(header.split(SPLIT_SEMI))
+        accepted = PriorityList.build(header.split(SPLIT_COMMA))
         default_priority = accepted.priority_of(default)
         star_priority = accepted.priority_of(STAR)
         default_ok = (default_priority.nil? && star_priority != 0.0) || default_priority

--- a/lib/webmachine/decision/flow.rb
+++ b/lib/webmachine/decision/flow.rb
@@ -245,7 +245,7 @@ module Webmachine
 
       # ETag in If-Match
       def g11
-        request_etags = request.if_match.split(SPLIT_SEMI).map {|etag| ETag.new(etag) }
+        request_etags = request.if_match.split(SPLIT_COMMA).map {|etag| ETag.new(etag) }
         request_etags.include?(ETag.new(resource.generate_etag)) ? :h10 : 412
       end
 
@@ -327,7 +327,7 @@ module Webmachine
 
       # Etag in if-none-match?
       def k13
-        request_etags = request.if_none_match.split(SPLIT_SEMI).map {|etag| ETag.new(etag) }
+        request_etags = request.if_none_match.split(SPLIT_COMMA).map {|etag| ETag.new(etag) }
         resource_etag = resource.generate_etag
         if resource_etag && request_etags.include?(ETag.new(resource_etag))
            :j18


### PR DESCRIPTION
I was reviewing the conneg code to refresh my memory on how subtype params matching worked and found this misnamed constant. The Accept header is never split on semi-colons (which are parts of the media type) but on commas.
