### PR TITLE
fix: implement rfc3986 Percent-Encoding decoder

### DIFF
--- a/lib/webmachine/dispatcher/route.rb
+++ b/lib/webmachine/dispatcher/route.rb
@@ -134,7 +134,7 @@ module Webmachine
               return false
             end
           when Symbol === spec.first
-            bindings[spec.first] = URI.decode(tokens.first)
+            bindings[spec.first] = Route.rfc3986_percent_decode(tokens.first)
           when spec.first == tokens.first
           else
             return false
@@ -145,6 +145,20 @@ module Webmachine
         end
       end
 
+      # Decode a string using the scheme described in RFC 3986 2.1. Percent-Encoding (https://www.ietf.org/rfc/rfc3986.txt)
+      def self.rfc3986_percent_decode(value)
+        s = StringScanner.new(value)
+        result = ''
+        until s.eos?
+          encoded_val = s.scan(/%([0-9a-fA-F]){2}/)
+          result << if encoded_val.nil?
+            s.getch
+          else
+            [encoded_val[1..-1]].pack('H*')
+          end
+        end
+        result
+      end
     end # class Route
   end # module Dispatcher
 end # module Webmachine

--- a/spec/webmachine/dispatcher/rfc3986_percent_decode_spec.rb
+++ b/spec/webmachine/dispatcher/rfc3986_percent_decode_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe Webmachine::Dispatcher::Route do
+  describe '#rfc3986_percent_decode' do
+    def call_subject(value)
+      Webmachine::Dispatcher::Route.rfc3986_percent_decode(value)
+    end
+
+    it 'does not change un-encoded strings' do
+      expect(call_subject('this is a normal string, I think')).to eq 'this is a normal string, I think'
+      expect(call_subject('')).to eq ''
+    end
+
+    it 'decodes percent encoded sequences' do
+      expect(call_subject('/tenants/esckimo+test%20%65')).to eq '/tenants/esckimo+test e'
+    end
+
+    it 'leaves incorrectly encoded sequences as is' do
+      expect(call_subject('/tenants/esckimo+test%2%65')).to eq '/tenants/esckimo+test%2e'
+    end
+  end
+end


### PR DESCRIPTION
Implemented a simple rfc3986 Percent-Encoding decoder.

The use of `URI.decode` in the router prints the following warnings:
```
.../webmachine-ruby/lib/webmachine/dispatcher/route.rb:137: warning: URI.unescape is obsolete
.../webmachine-ruby/lib/webmachine/dispatcher/route.rb:137: warning: URI.unescape is obsolete
```

`URI.unescape` is deprecated with no replacement.
> This method is obsolete and should not be used. Instead, use CGI.unescape, URI.decode_www_form or URI.decode_www_form_component depending on your specific use case.