### PR TITLE
Fix the build for ruby 3.0.x (but not 3.1.0-dev yet)

### DIFF
--- a/lib/webmachine/dispatcher/route.rb
+++ b/lib/webmachine/dispatcher/route.rb
@@ -58,7 +58,7 @@ module Webmachine
       #   @yield [req] an optional guard block
       #   @yieldparam [Request] req the request object
       # @see Dispatcher#add_route
-      def initialize(path_spec, *args)
+      def initialize(path_spec, *args, &block)
         if args.last.is_a? Hash
           bindings = args.pop
         else
@@ -67,7 +67,7 @@ module Webmachine
 
         resource = args.pop
         guards = args
-        guards << Proc.new if block_given?
+        guards << block if block_given?
 
         warn t('match_all_symbol') if path_spec.include? MATCH_ALL_STR
 

--- a/lib/webmachine/translation.rb
+++ b/lib/webmachine/translation.rb
@@ -13,7 +13,7 @@ module Webmachine
     #   variables to interpolate.
     # @return [String] the interpolated string
     def t(key, options={})
-      ::I18n.t(key, options.merge(:scope => :webmachine))
+      ::I18n.t(key, **options.merge(:scope => :webmachine))
     end
   end
 end

--- a/spec/webmachine/events_spec.rb
+++ b/spec/webmachine/events_spec.rb
@@ -48,7 +48,7 @@ describe Webmachine::Events do
 
   describe ".unsubscribe" do
     it "calls the backend" do
-      subscriber = described_class.subscribe('test.event') { }
+      subscriber = described_class.subscribe('test.event', Proc.new { })
 
       expect(described_class.backend).to receive(:unsubscribe).with(subscriber)
 

--- a/spec/webmachine/events_spec.rb
+++ b/spec/webmachine/events_spec.rb
@@ -48,7 +48,7 @@ describe Webmachine::Events do
 
   describe ".unsubscribe" do
     it "calls the backend" do
-      subscriber = described_class.subscribe('test.event', Proc.new { })
+      subscriber = described_class.subscribe('test.event') { }
 
       expect(described_class.backend).to receive(:unsubscribe).with(subscriber)
 

--- a/webmachine.gemspec
+++ b/webmachine.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency(%q<i18n>, [">= 0.4.0"])
   gem.add_runtime_dependency(%q<multi_json>)
-  gem.add_runtime_dependency(%q<as-notifications>, ["~> 1.0"])
+  gem.add_runtime_dependency(%q<as-notifications>, [">= 1.0.2", "< 2.0"])
 
   gem.add_development_dependency(%q<webrick>, ["~> 1.7.0"])
 

--- a/webmachine.gemspec
+++ b/webmachine.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency(%q<multi_json>)
   gem.add_runtime_dependency(%q<as-notifications>, ["~> 1.0"])
 
+  gem.add_development_dependency(%q<webrick>, ["~> 1.7.0"])
+
   ignores = File.read(".gitignore").split(/\r?\n/).reject{ |f| f =~ /^(#.+|\s*)$/ }.map {|f| Dir[f] }.flatten
   gem.files = (Dir['**/*','.gitignore'] - ignores).reject {|f| !File.file?(f) }
   gem.test_files = (Dir['spec/**/*','features/**/*','.gitignore'] - ignores).reject {|f| !File.file?(f) }


### PR DESCRIPTION
## Fix:

1. dev dependency for `webrick`
1. keyword arguments are stricter with respect to options hashes (double-splat fixes)
1. `Proc.new` requires an empty block where a block is not given

## Does not fix:

- ~~gem `as-notifications` will need updating as per point 3. above (though I'm not sure we actually call [this](https://github.com/bernd/as-notifications/blob/v1.0.0/lib/as/notifications/fanout.rb#L18) in such a way that it would use the default `Proc.new` for the argument, so it's probably just a ticking time bomb)~~
- `3.1.0-dev` is broken as `Time::RFC_*` constants aren't there right now