### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/webmachine.gemspec
+++ b/webmachine.gemspec
@@ -15,6 +15,13 @@ Gem::Specification.new do |gem|
   gem.email = ["sean@basho.com"]
   gem.license = "Apache-2.0"
 
+  gem.metadata["bug_tracker_uri"] = "#{gem.homepage}/issues"
+  gem.metadata["changelog_uri"] = "#{gem.homepage}/blob/HEAD/CHANGELOG.md"
+  gem.metadata["documentation_uri"] = "https://www.rubydoc.info/gems/webmachine/#{gem.version}"
+  gem.metadata["homepage_uri"] = gem.homepage
+  gem.metadata["source_code_uri"] = gem.homepage
+  gem.metadata["wiki_uri"] = "#{gem.homepage}/wiki"
+
   gem.add_runtime_dependency(%q<i18n>, [">= 0.4.0"])
   gem.add_runtime_dependency(%q<multi_json>)
   gem.add_runtime_dependency(%q<as-notifications>, [">= 1.0.2", "< 2.0"])

--- a/webmachine.gemspec
+++ b/webmachine.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
     the confusion of going through a CGI-style interface like Rack. It is strongly influenced
     by the original Erlang project of the same name and shares its opinionated nature about HTTP.
   DESC
-  gem.homepage = "http://github.com/seancribbs/webmachine-ruby"
+  gem.homepage = "https://github.com/webmachine/webmachine-ruby"
   gem.authors = ["Sean Cribbs"]
   gem.email = ["sean@basho.com"]
   gem.license = "Apache-2.0"


### PR DESCRIPTION
### Proposed Change

- Set the gem homepage to the current git repository URI.
- Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `homepage_uri`, `source_code_uri`, and `wiki_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/webmachine), via the Rubygems API, and the `gem` and `bundle` command-line tools with the next release.