### PR TITLE
Fix flaky test: ensure the `json` gem is loaded

### DIFF
--- a/spec/webmachine/adapters/rack_spec.rb
+++ b/spec/webmachine/adapters/rack_spec.rb
@@ -3,6 +3,7 @@ require 'webmachine/adapters/rack'
 require 'spec_helper'
 require 'webmachine/spec/adapter_lint'
 require 'rack/test'
+require 'json'
 
 describe Webmachine::Adapters::Rack do
   it_should_behave_like :adapter_lint do


### PR DESCRIPTION
### Context

It seems there are some tests that result in the `json` gem being loaded. If the `spec/webmachine/adapters/rack_spec.rb:57` test happens to run before these tests, the `json` gem will not be loaded and the test fails. This is reproducible with the following command.

```sh
rspec --seed 34885
```

### Change

Add a require statement for the `json` gem. This will ensure the gem is always loaded when the test runs and remove the flaky behaviour.

Fixes #270.