### PR TITLE
chore(release): version 2.0.0.beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### HEAD
 
+### 2.0.0.beta Mar 30, 2023
+
+* Drop support for ruby 2.3, 2.4, and 2.5
+* Remove the HTTPkit adapter
+* Format cookie 'Expires' timestamps as per RFC 2616
+
 ### 1.6.0 June 22, 2021
 
 * fix: replace missed URI.decode with new Route.rfc3986_percent_decode (#261)

--- a/lib/webmachine/version.rb
+++ b/lib/webmachine/version.rb
@@ -1,6 +1,6 @@
 ﻿module Webmachine
   # Library version
-  VERSION = '1.6.0'.freeze
+  VERSION = '2.0.0.beta'.freeze
 
   # String for use in "Server" HTTP response header, which includes
   # the {VERSION}.


### PR DESCRIPTION
Hi peeps. I'm upgrading from ruby 2 to 3 in a couple of my projects, and needed to push out the latest webmachine gem with its support for ruby 3. I believe it should be a major version, as we're dropping support for old rubies, but I wasn't 100% confident in that call, and can see that there might be other points of view, so I've pushed it out as `2.0.0.beta`.

I was following the instructions in `RELEASING.md` and have discovered that they no longer work, as we now have branch protection on. They should probably be updated, but also, we should probably be releasing from Github Actions now instead of our local machines 😱.