### PR TITLE
CI: add Ruby 3.3 to the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,14 +9,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: ["2.6", "2.7", "3.0", "3.1", "3.2"]
+        ruby_version: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3"]
         experimental: [false]
         include:
           - ruby_version: "ruby-head"
             experimental: true
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}


### PR DESCRIPTION
Ruby 3.3 has [been released](https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/)! Let's add it to the CI build matrix for confidence in compatibility.