### PR TITLE
Add `base64` as a runtime dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,3 +24,7 @@ end
 platforms :jruby do
   gem 'jruby-openssl'
 end
+
+if RUBY_VERSION >= '3.4'
+  gem 'mutex_m' # TODO: remove this once as-notifications has such a dependency
+end

--- a/webmachine.gemspec
+++ b/webmachine.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('i18n', ['>= 0.4.0'])
   gem.add_runtime_dependency('multi_json')
   gem.add_runtime_dependency('as-notifications', ['>= 1.0.2', '< 2.0'])
+  gem.add_runtime_dependency('base64')
 
   gem.add_development_dependency('webrick', ['~> 1.7.0'])
   gem.add_development_dependency('standard', ['~> 1.21'])


### PR DESCRIPTION
### Context

Webmachine uses the `base64` library from the Ruby standard library:

https://github.com/webmachine/webmachine-ruby/blob/45d7513aaf082961be85de024d76f8bbf06a0f98/lib/webmachine/decision/flow.rb#L3

In the forthcoming Ruby 3.4, the `base64` library will be come a 'bundled' library. It must be included in gem sets to be used with Bundler.

In [Ruby 3.3](https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/) a deprecation warning is shown:

> lib/webmachine/decision/flow.rb:3: warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec.

Example: https://github.com/webmachine/webmachine-ruby/actions/runs/7955436555/job/21714422307?pr=276#step:5:5

### Change

Add `base64` as a runtime dependency in the gemspec.