### PR TITLE
Don't include the `doc/`, `pkg/`, or `vendor/` directory in the gem package

### DIFF
--- a/webmachine.gemspec
+++ b/webmachine.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('standard', ['~> 1.21'])
   ignores = File.read('.gitignore').split(/\r?\n/).reject { |f| f =~ /^(#.+|\s*)$/ }.map { |f| Dir[f] }.flatten
   gem.files = (Dir['**/*', '.gitignore'] - ignores).reject do |f|
-    !File.file?(f) || f.start_with?(*%w[. Gemfile RELEASING Rakefile memory_test spec webmachine.gemspec])
+    !File.file?(f) || f.start_with?(*%w[. Gemfile RELEASING Rakefile doc/ memory_test pkg/ spec/ vendor/ webmachine.gemspec])
   end
 end


### PR DESCRIPTION
We have a few Rake and Bundler tasks produce files in the `doc/`, `pkg/`, and `vendor/` directories. Files in these directories shouldn't be added to Git or included in the gem package published to rubygems.org upon release.

We have `.gitignore` entries that prevent these files from being added to the Git repository. Let's update the gemspec to ensure these files aren't added to the gem package.