### PR TITLE
Release version 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ### HEAD
 
+### 2.0.1 Feb 27, 2024
+
+* Don't include the `doc/`, `pkg/`, or `vendor/` directory in the gem package
+* Add `base64` as a runtime dependency
+* Add support for Ruby 3.3
+* Fix Rubocop issues
+
 ### 2.0.0 Mar 31, 2023
 
 * Add support for ruby 3.0, 3.1 and 3.2

--- a/lib/webmachine/version.rb
+++ b/lib/webmachine/version.rb
@@ -1,6 +1,6 @@
 ﻿module Webmachine
   # Library version
-  VERSION = '2.0.0'.freeze
+  VERSION = '2.0.1'.freeze
 
   # String for use in "Server" HTTP response header, which includes
   # the {VERSION}.


### PR DESCRIPTION
🎉 

Following the release guide: https://github.com/webmachine/webmachine-ruby/blob/master/RELEASING.md

I humbly suggest we cut a point release.