### PR TITLE
Add support for Ruby 3.4 and 4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3"]
+        ruby_version: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4", "4.0"]
         experimental: [false]
         include:
           - ruby_version: "ruby-head"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
             experimental: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ if RUBY_VERSION >= '3.4'
 end
 
 if RUBY_VERSION >= '4.0'
-  gem 'pstore'
   gem 'logger'
   gem 'ostruct'
+  gem 'pstore'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -2,17 +2,17 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'rake', '~> 12.0'
+  gem 'rake', '~> 13'
   gem 'standard', '~> 1.21'
   gem 'webrick', '~> 1.7'
 end
 
 group :test do
-  gem 'rack', '~> 2.0'
-  gem 'rack-test', '~> 0.7'
+  gem 'rack', '~> 2'
+  gem 'rack-test', '~> 2'
   gem 'rspec', '~> 3.0', '>= 3.6.0'
   gem 'rspec-its', '~> 1.2'
-  gem 'websocket_parser', '~>1.0'
+  gem 'websocket_parser', '~> 1.0'
 end
 
 group :docs do

--- a/lib/webmachine/trace/pstore_trace_store.rb
+++ b/lib/webmachine/trace/pstore_trace_store.rb
@@ -1,16 +1,15 @@
-require 'pstore'
-
 module Webmachine
   module Trace
-    # Implements a trace storage using PStore from Ruby's standard
-    # library. To use this trace store, specify the :pstore engine
-    # and a path where it can store traces:
+    # Implements a trace storage using the pstore gem. To use this trace store,
+    # add `pstore` to your Gemfile and specify the :pstore engine and a path
+    # where it can store traces:
     # @example
     #   Webmachine::Trace.trace_store = :pstore, "/tmp/webmachine.trace"
     class PStoreTraceStore
       # @api private
       # @param [String] path where to store traces in a PStore
       def initialize(path)
+        require 'pstore' # JIT load of the pstore gem. Avoid requiring the dependency when this class is not used.
         @pstore = PStore.new(path)
       end
 


### PR DESCRIPTION
Ruby [3.4](https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/) and [4.0](https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/) have been released! Let's add them to the CI build matrix for confidence in compatibility.